### PR TITLE
M3: Harden runtime library loading and path handling across OSes

### DIFF
--- a/library.go
+++ b/library.go
@@ -1,19 +1,344 @@
 package chroma
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 )
 
 const envLibPath = "CHROMA_LIB_PATH"
 
-func resolveLibraryPath(path string) (string, error) {
-	if path == "" {
-		path = os.Getenv(envLibPath)
+type getenvFunc func(string) string
+type statFunc func(string) (os.FileInfo, error)
+type absPathFunc func(string) (string, error)
+
+type libraryCandidate struct {
+	path   string
+	source string
+}
+
+type libraryLoadPlan struct {
+	goos         string
+	configured   string
+	configSource string
+	candidates   []libraryCandidate
+	warnings     []string
+}
+
+type candidateSet struct {
+	ordered []libraryCandidate
+	seen    map[string]struct{}
+}
+
+func newCandidateSet(capacity int) candidateSet {
+	return candidateSet{
+		ordered: make([]libraryCandidate, 0, capacity),
+		seen:    make(map[string]struct{}, capacity),
 	}
+}
+
+func (set *candidateSet) add(path string, source string) {
+	path = strings.TrimSpace(path)
 	if path == "" {
-		return "", errors.New("library path not specified and CHROMA_LIB_PATH not set")
+		return
 	}
-	return path, nil
+	if _, ok := set.seen[path]; ok {
+		return
+	}
+	set.seen[path] = struct{}{}
+	set.ordered = append(set.ordered, libraryCandidate{
+		path:   path,
+		source: source,
+	})
+}
+
+func (set *candidateSet) candidates() []libraryCandidate {
+	return set.ordered
+}
+
+func resolveLibraryLoadPlan(path string, goos string, getenv getenvFunc, stat statFunc) (libraryLoadPlan, error) {
+	return resolveLibraryLoadPlanWithAbs(path, goos, getenv, stat, filepath.Abs)
+}
+
+func resolveLibraryLoadPlanWithAbs(path string, goos string, getenv getenvFunc, stat statFunc, abs absPathFunc) (libraryLoadPlan, error) {
+	configuredPath, source := resolveConfiguredLibraryPath(path, getenv)
+	if configuredPath == "" {
+		return libraryLoadPlan{}, errors.Errorf(
+			"library path not specified; pass Init(libPath) or set %s (expected %q on %s)",
+			envLibPath,
+			defaultLibraryFilename(goos),
+			goos,
+		)
+	}
+
+	candidates, candidateWarnings := buildLibraryPathCandidates(configuredPath, goos, stat)
+	candidates, absWarnings := appendAbsolutePathCandidates(candidates, goos, abs)
+	if len(candidates) == 0 {
+		return libraryLoadPlan{}, errors.Errorf("library path %q resolved to no load candidates", configuredPath)
+	}
+
+	warnings := append([]string{}, candidateWarnings...)
+	warnings = append(warnings, absWarnings...)
+
+	return libraryLoadPlan{
+		goos:         goos,
+		configured:   configuredPath,
+		configSource: source,
+		candidates:   candidates,
+		warnings:     warnings,
+	}, nil
+}
+
+func resolveConfiguredLibraryPath(path string, getenv getenvFunc) (string, string) {
+	configuredPath := strings.TrimSpace(path)
+	if configuredPath != "" {
+		return configuredPath, "Init(libPath)"
+	}
+
+	if getenv == nil {
+		return "", ""
+	}
+
+	configuredPath = strings.TrimSpace(getenv(envLibPath))
+	if configuredPath != "" {
+		return configuredPath, envLibPath
+	}
+
+	return "", ""
+}
+
+func buildLibraryPathCandidates(path string, goos string, stat statFunc) ([]libraryCandidate, []string) {
+	normalized := normalizePathSeparators(path, goos)
+	extension := libraryFileExtension(goos)
+	defaultName := defaultLibraryFilename(goos)
+
+	candidates := newCandidateSet(6)
+	warnings := make([]string, 0)
+
+	isDirectory, directoryWarning := looksLikeDirectoryPath(normalized, stat)
+	if directoryWarning != "" {
+		warnings = append(warnings, directoryWarning)
+	}
+	if isDirectory {
+		candidates.add(joinPathForOS(normalized, defaultName, goos), "derived:directory-default-name")
+		return candidates.candidates(), warnings
+	}
+
+	candidates.add(normalized, "configured")
+
+	if pathExtForOS(normalized) == "" {
+		candidates.add(normalized+extension, "derived:added-extension")
+
+		if goos != "windows" {
+			dir, file := splitPathNormalized(normalized)
+			if file != "" && !strings.HasPrefix(file, "lib") {
+				candidates.add(joinPathForOS(dir, "lib"+file+extension, goos), "derived:added-lib-prefix")
+			}
+		}
+	}
+
+	return candidates.candidates(), warnings
+}
+
+func appendAbsolutePathCandidates(candidates []libraryCandidate, goos string, abs absPathFunc) ([]libraryCandidate, []string) {
+	withAbsolute := newCandidateSet(len(candidates) * 2)
+
+	for _, candidate := range candidates {
+		withAbsolute.add(candidate.path, candidate.source)
+	}
+
+	warnings := make([]string, 0)
+	for _, candidate := range candidates {
+		if !strings.ContainsAny(candidate.path, `/\`) {
+			continue
+		}
+		if isAbsolutePathForOS(candidate.path, goos) {
+			continue
+		}
+		if abs == nil {
+			warnings = append(warnings, fmt.Sprintf("skipped absolute fallback for [%s] %q: abs resolver unavailable", candidate.source, candidate.path))
+			continue
+		}
+
+		absPath, err := abs(candidate.path)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("skipped absolute fallback for [%s] %q: %v", candidate.source, candidate.path, err))
+			continue
+		}
+
+		if goos == "windows" {
+			absPath = strings.ReplaceAll(absPath, "/", `\`)
+		} else {
+			absPath = strings.ReplaceAll(absPath, `\`, "/")
+		}
+		withAbsolute.add(absPath, "derived:absolute-fallback")
+	}
+
+	return withAbsolute.candidates(), warnings
+}
+
+func formatLoadAttempt(candidate libraryCandidate, err error) string {
+	if err == nil {
+		return fmt.Sprintf("[%s] %s (loader returned nil handle; unexpected)", candidate.source, candidate.path)
+	}
+	return fmt.Sprintf("[%s] %s (%v)", candidate.source, candidate.path, err)
+}
+
+func formatLibraryLoadError(plan libraryLoadPlan, attempts []string) error {
+	candidateDescriptions := make([]string, 0, len(plan.candidates))
+	for _, candidate := range plan.candidates {
+		candidateDescriptions = append(candidateDescriptions, fmt.Sprintf("[%s] %s", candidate.source, candidate.path))
+	}
+
+	message := fmt.Sprintf(
+		"failed to load Chroma library on %s using %s=%q; attempted paths: [%s]; expected extension: %q (default filename: %q); loader errors: %s",
+		plan.goos,
+		plan.configSource,
+		plan.configured,
+		strings.Join(candidateDescriptions, ", "),
+		libraryFileExtension(plan.goos),
+		defaultLibraryFilename(plan.goos),
+		strings.Join(attempts, "; "),
+	)
+	if len(plan.warnings) > 0 {
+		message = fmt.Sprintf("%s; path resolution warnings: %s", message, strings.Join(plan.warnings, "; "))
+	}
+
+	return errors.New(message)
+}
+
+func defaultLibraryFilename(goos string) string {
+	switch goos {
+	case "windows":
+		return "chroma_go_shim.dll"
+	case "darwin":
+		return "libchroma_go_shim.dylib"
+	default:
+		return "libchroma_go_shim.so"
+	}
+}
+
+func libraryFileExtension(goos string) string {
+	switch goos {
+	case "windows":
+		return ".dll"
+	case "darwin":
+		return ".dylib"
+	default:
+		return ".so"
+	}
+}
+
+func normalizePathSeparators(path string, goos string) string {
+	if goos == "windows" {
+		return strings.ReplaceAll(path, "/", `\`)
+	}
+	return strings.ReplaceAll(path, `\`, "/")
+}
+
+func looksLikeDirectoryPath(path string, stat statFunc) (bool, string) {
+	if strings.HasSuffix(path, "/") || strings.HasSuffix(path, `\`) {
+		if stat == nil {
+			return true, ""
+		}
+
+		info, err := stat(path)
+		if err == nil {
+			if info.IsDir() {
+				return true, ""
+			}
+			return true, fmt.Sprintf("path %q ends with a directory separator but stat reports a non-directory", path)
+		}
+
+		return true, fmt.Sprintf("path %q ends with a directory separator but stat failed: %v", path, err)
+	}
+	if stat == nil {
+		return false, ""
+	}
+
+	info, err := stat(path)
+	if err == nil {
+		return info.IsDir(), ""
+	}
+	if os.IsNotExist(err) {
+		return false, ""
+	}
+
+	return false, fmt.Sprintf("stat(%q) failed while inferring directory path: %v", path, err)
+}
+
+func pathExtForOS(path string) string {
+	_, file := splitPathNormalized(path)
+	lastDot := strings.LastIndex(file, ".")
+	if lastDot <= 0 || lastDot == len(file)-1 {
+		return ""
+	}
+	return strings.ToLower(file[lastDot:])
+}
+
+func splitPathNormalized(path string) (string, string) {
+	normalized := strings.ReplaceAll(path, `\`, "/")
+	lastSep := strings.LastIndex(normalized, "/")
+	if lastSep == -1 {
+		return "", normalized
+	}
+
+	dir := normalized[:lastSep]
+	file := normalized[lastSep+1:]
+	return dir, file
+}
+
+func joinPathForOS(dir string, file string, goos string) string {
+	if dir == "" || dir == "." {
+		return file
+	}
+
+	if goos == "windows" {
+		normalizedDir := strings.ReplaceAll(dir, "/", `\`)
+		if normalizedDir == `\` {
+			return `\` + file
+		}
+		cleanDir := strings.TrimRight(normalizedDir, `\`)
+		if cleanDir == "" {
+			return file
+		}
+		return cleanDir + `\` + file
+	}
+
+	normalizedDir := strings.ReplaceAll(dir, `\`, "/")
+	if normalizedDir == "/" {
+		return "/" + file
+	}
+
+	cleanDir := strings.TrimRight(normalizedDir, "/")
+	if cleanDir == "" {
+		return file
+	}
+
+	return cleanDir + "/" + file
+}
+
+func isAbsolutePathForOS(path string, goos string) bool {
+	if goos != "windows" {
+		return strings.HasPrefix(path, "/")
+	}
+
+	if strings.HasPrefix(path, `\\`) {
+		return true
+	}
+
+	if len(path) < 3 {
+		return false
+	}
+
+	drive := path[0]
+	hasDriveLetter := (drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')
+	if !hasDriveLetter || path[1] != ':' {
+		return false
+	}
+
+	return path[2] == '\\' || path[2] == '/'
 }

--- a/library_test.go
+++ b/library_test.go
@@ -1,0 +1,500 @@
+package chroma
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func notFoundStat(string) (os.FileInfo, error) {
+	return nil, os.ErrNotExist
+}
+
+func containsCandidatePath(candidates []libraryCandidate, want string) bool {
+	for _, candidate := range candidates {
+		if candidate.path == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsCandidateWithSource(candidates []libraryCandidate, path string, source string) bool {
+	for _, candidate := range candidates {
+		if candidate.path == path && candidate.source == source {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeForHost(path string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ReplaceAll(path, "/", `\`)
+	}
+	return strings.ReplaceAll(path, `\`, "/")
+}
+
+func TestResolveLibraryLoadPlanRequiresPath(t *testing.T) {
+	_, err := resolveLibraryLoadPlan("", runtime.GOOS, func(string) string { return "" }, notFoundStat)
+	if err == nil {
+		t.Fatal("expected an error when no explicit path or CHROMA_LIB_PATH is provided")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, envLibPath) {
+		t.Fatalf("expected missing-path error to mention %s, got: %q", envLibPath, msg)
+	}
+	if !strings.Contains(msg, defaultLibraryFilename(runtime.GOOS)) {
+		t.Fatalf("expected missing-path error to mention expected filename, got: %q", msg)
+	}
+}
+
+func TestResolveLibraryLoadPlanUsesInitPathBeforeEnv(t *testing.T) {
+	plan, err := resolveLibraryLoadPlan(
+		"./shim/target/debug/chroma_go_shim",
+		runtime.GOOS,
+		func(string) string { return "/ignored/from/env" },
+		notFoundStat,
+	)
+	if err != nil {
+		t.Fatalf("resolveLibraryLoadPlan returned error: %v", err)
+	}
+
+	if plan.configSource != "Init(libPath)" {
+		t.Fatalf("expected Init path source, got: %s", plan.configSource)
+	}
+
+	expectedBase := normalizePathSeparators("./shim/target/debug/chroma_go_shim", runtime.GOOS)
+	if !containsCandidateWithSource(plan.candidates, expectedBase, "configured") {
+		t.Fatalf("expected candidates to include configured path %q, got: %#v", expectedBase, plan.candidates)
+	}
+}
+
+func TestResolveLibraryLoadPlanUsesEnvWhenInitPathEmpty(t *testing.T) {
+	plan, err := resolveLibraryLoadPlan(
+		"",
+		runtime.GOOS,
+		func(key string) string {
+			if key == envLibPath {
+				return "./shim/target/debug/chroma_go_shim"
+			}
+			return ""
+		},
+		notFoundStat,
+	)
+	if err != nil {
+		t.Fatalf("resolveLibraryLoadPlan returned error: %v", err)
+	}
+
+	if plan.configSource != envLibPath {
+		t.Fatalf("expected env path source, got: %s", plan.configSource)
+	}
+}
+
+func TestBuildLibraryPathCandidatesMissingExtension(t *testing.T) {
+	tests := []struct {
+		name  string
+		goos  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "linux missing extension adds .so variants",
+			goos:  "linux",
+			input: "/tmp/chroma_go_shim",
+			want:  []string{"/tmp/chroma_go_shim.so", "/tmp/libchroma_go_shim.so"},
+		},
+		{
+			name:  "darwin missing extension adds .dylib variants",
+			goos:  "darwin",
+			input: "/tmp/chroma_go_shim",
+			want:  []string{"/tmp/chroma_go_shim.dylib", "/tmp/libchroma_go_shim.dylib"},
+		},
+		{
+			name:  "windows missing extension adds .dll only",
+			goos:  "windows",
+			input: `C:/tmp/chroma_go_shim`,
+			want:  []string{`C:\tmp\chroma_go_shim`, `C:\tmp\chroma_go_shim.dll`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, warnings := buildLibraryPathCandidates(tt.input, tt.goos, notFoundStat)
+			if len(warnings) != 0 {
+				t.Fatalf("expected no warnings for normal candidate generation, got: %#v", warnings)
+			}
+			for _, want := range tt.want {
+				if !containsCandidatePath(got, want) {
+					t.Fatalf("expected candidates to include %q, got: %#v", want, got)
+				}
+			}
+
+			if tt.goos == "windows" && containsCandidatePath(got, `C:\tmp\libchroma_go_shim.dll`) {
+				t.Fatalf("did not expect lib-prefixed Windows candidate, got: %#v", got)
+			}
+		})
+	}
+}
+
+func TestBuildLibraryPathCandidatesWithExistingExtension(t *testing.T) {
+	got, warnings := buildLibraryPathCandidates("/tmp/libchroma_go_shim.so", "linux", notFoundStat)
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for existing-extension path, got: %#v", warnings)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one candidate for an already-qualified path, got %d (%#v)", len(got), got)
+	}
+	if got[0].source != "configured" {
+		t.Fatalf("expected configured source for existing-extension path, got: %#v", got)
+	}
+}
+
+func TestBuildLibraryPathCandidatesDirectoryInput(t *testing.T) {
+	dir := t.TempDir()
+	got, warnings := buildLibraryPathCandidates(dir, runtime.GOOS, os.Stat)
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for directory path, got: %#v", warnings)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("expected one directory-derived candidate, got %d (%#v)", len(got), got)
+	}
+
+	want := normalizePathSeparators(filepath.Join(dir, defaultLibraryFilename(runtime.GOOS)), runtime.GOOS)
+	if got[0].path != want {
+		t.Fatalf("expected candidate %q, got %q", want, got[0].path)
+	}
+	if got[0].source != "derived:directory-default-name" {
+		t.Fatalf("expected directory-derived source, got: %#v", got[0])
+	}
+}
+
+func TestLooksLikeDirectoryPathWithTrailingSeparator(t *testing.T) {
+	isDir, warning := looksLikeDirectoryPath("/tmp/chroma/", nil)
+	if warning != "" {
+		t.Fatalf("expected no warning for trailing slash directory hint, got: %q", warning)
+	}
+	if !isDir {
+		t.Fatal("expected trailing slash path to be treated as directory")
+	}
+
+	isDir, warning = looksLikeDirectoryPath(`C:\tmp\chroma\`, nil)
+	if warning != "" {
+		t.Fatalf("expected no warning for trailing backslash directory hint, got: %q", warning)
+	}
+	if !isDir {
+		t.Fatal("expected trailing backslash path to be treated as directory")
+	}
+}
+
+func TestLooksLikeDirectoryPathTrailingSeparatorWarnsWhenStatFails(t *testing.T) {
+	isDir, warning := looksLikeDirectoryPath("/tmp/chroma/", notFoundStat)
+	if !isDir {
+		t.Fatal("expected trailing separator path to remain directory-intent even on stat failure")
+	}
+	if !strings.Contains(warning, "stat failed") {
+		t.Fatalf("expected trailing-separator stat failure warning, got: %q", warning)
+	}
+}
+
+func TestLooksLikeDirectoryPathNilStatWithoutTrailingSeparator(t *testing.T) {
+	isDir, warning := looksLikeDirectoryPath("/tmp/chroma", nil)
+	if isDir {
+		t.Fatal("expected non-trailing path with nil stat to not infer directory")
+	}
+	if warning != "" {
+		t.Fatalf("expected no warning with nil stat and non-trailing path, got: %q", warning)
+	}
+}
+
+func TestResolveLibraryLoadPlanAddsAbsoluteFallbackForRelativePaths(t *testing.T) {
+	relative := filepath.Join("shim", "target", "debug", defaultLibraryFilename(runtime.GOOS))
+	relative = normalizePathSeparators(relative, runtime.GOOS)
+
+	plan, err := resolveLibraryLoadPlan(relative, runtime.GOOS, nil, notFoundStat)
+	if err != nil {
+		t.Fatalf("resolveLibraryLoadPlan returned error: %v", err)
+	}
+
+	absolute, err := filepath.Abs(relative)
+	if err != nil {
+		t.Fatalf("filepath.Abs returned error: %v", err)
+	}
+	absolute = normalizeForHost(absolute)
+
+	if !containsCandidateWithSource(plan.candidates, relative, "configured") {
+		t.Fatalf("expected candidates to include configured path %q, got %#v", relative, plan.candidates)
+	}
+	if !containsCandidateWithSource(plan.candidates, absolute, "derived:absolute-fallback") {
+		t.Fatalf("expected candidates to include absolute fallback path %q, got %#v", absolute, plan.candidates)
+	}
+}
+
+func TestResolveLibraryLoadPlanSkipsAbsoluteFallbackForBareFilename(t *testing.T) {
+	plan, err := resolveLibraryLoadPlan("libchroma_go_shim.so", "linux", nil, notFoundStat)
+	if err != nil {
+		t.Fatalf("resolveLibraryLoadPlan returned error: %v", err)
+	}
+
+	for _, candidate := range plan.candidates {
+		if candidate.source == "derived:absolute-fallback" {
+			t.Fatalf("did not expect absolute fallback for bare filename, got candidates %#v", plan.candidates)
+		}
+	}
+}
+
+func TestResolveLibraryLoadPlanIncludesAbsoluteFallbackWarnings(t *testing.T) {
+	plan, err := resolveLibraryLoadPlanWithAbs(
+		"./shim/target/debug/libchroma_go_shim",
+		"linux",
+		nil,
+		notFoundStat,
+		func(string) (string, error) {
+			return "", errors.New("cwd unavailable")
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveLibraryLoadPlanWithAbs returned error: %v", err)
+	}
+
+	if len(plan.warnings) == 0 {
+		t.Fatal("expected warning when absolute fallback resolution fails")
+	}
+	if !strings.Contains(plan.warnings[0], "cwd unavailable") {
+		t.Fatalf("expected warning to include abs error, got: %#v", plan.warnings)
+	}
+}
+
+func TestAppendAbsolutePathCandidatesWarnsWhenAbsResolverNil(t *testing.T) {
+	base := []libraryCandidate{
+		{path: "./shim/target/debug/libchroma_go_shim", source: "configured"},
+	}
+
+	got, warnings := appendAbsolutePathCandidates(base, "linux", nil)
+	if len(got) != 1 {
+		t.Fatalf("expected original candidate to remain, got %#v", got)
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected warning when abs resolver is nil")
+	}
+	if !strings.Contains(warnings[0], "abs resolver unavailable") {
+		t.Fatalf("expected abs-resolver warning, got %#v", warnings)
+	}
+}
+
+func TestResolveLibraryLoadPlanIncludesDirectoryStatWarnings(t *testing.T) {
+	plan, err := resolveLibraryLoadPlan(
+		"./restricted/chroma_go_shim",
+		"linux",
+		nil,
+		func(string) (os.FileInfo, error) {
+			return nil, os.ErrPermission
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveLibraryLoadPlan returned error: %v", err)
+	}
+
+	if len(plan.warnings) == 0 {
+		t.Fatal("expected directory stat warning to be captured")
+	}
+	if !strings.Contains(plan.warnings[0], "ErrPermission") && !strings.Contains(plan.warnings[0], "permission") {
+		t.Fatalf("expected warning to mention permission issue, got: %#v", plan.warnings)
+	}
+}
+
+func TestPathExtForOSEdgeCases(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "libchroma_go_shim.so", want: ".so"},
+		{path: "/tmp/.so", want: ""},
+		{path: "/tmp/chroma.", want: ""},
+		{path: "/tmp/noext", want: ""},
+		{path: `C:\tmp\name.DLL`, want: ".dll"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := pathExtForOS(tt.path)
+			if got != tt.want {
+				t.Fatalf("pathExtForOS(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveConfiguredLibraryPathWithNilGetenv(t *testing.T) {
+	path, source := resolveConfiguredLibraryPath("", nil)
+	if path != "" || source != "" {
+		t.Fatalf("expected empty path/source when getenv is nil and no explicit path, got (%q, %q)", path, source)
+	}
+
+	path, source = resolveConfiguredLibraryPath(" ./shim/target/debug/libchroma_go_shim.so ", nil)
+	if path != "./shim/target/debug/libchroma_go_shim.so" {
+		t.Fatalf("expected trimmed explicit path, got %q", path)
+	}
+	if source != "Init(libPath)" {
+		t.Fatalf("expected Init source for explicit path, got %q", source)
+	}
+}
+
+func TestIsAbsolutePathForOSTable(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		path string
+		want bool
+	}{
+		{name: "unix absolute", goos: "linux", path: "/tmp/lib.so", want: true},
+		{name: "unix relative", goos: "linux", path: "tmp/lib.so", want: false},
+		{name: "windows drive absolute", goos: "windows", path: `C:\tmp\shim.dll`, want: true},
+		{name: "windows drive relative", goos: "windows", path: `C:tmp\shim.dll`, want: false},
+		{name: "windows unc absolute", goos: "windows", path: `\\server\share\shim.dll`, want: true},
+		{name: "windows relative", goos: "windows", path: `tmp\shim.dll`, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAbsolutePathForOS(tt.path, tt.goos)
+			if got != tt.want {
+				t.Fatalf("isAbsolutePathForOS(%q, %q) = %v, want %v", tt.path, tt.goos, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatLoadAttempt(t *testing.T) {
+	candidate := libraryCandidate{path: "/tmp/libchroma_go_shim.so", source: "configured"}
+
+	msgWithErr := formatLoadAttempt(candidate, errors.New("open failed"))
+	if !strings.Contains(msgWithErr, "[configured]") || !strings.Contains(msgWithErr, "open failed") {
+		t.Fatalf("expected formatted load attempt to include source and error, got: %q", msgWithErr)
+	}
+
+	msgNilHandle := formatLoadAttempt(candidate, nil)
+	if !strings.Contains(msgNilHandle, "unexpected") {
+		t.Fatalf("expected nil-handle message to include severity hint, got: %q", msgNilHandle)
+	}
+}
+
+func TestFormatLibraryLoadErrorIncludesCandidateKindsAndWarnings(t *testing.T) {
+	plan := libraryLoadPlan{
+		goos:         "linux",
+		configured:   "./shim/target/debug/libchroma_go_shim",
+		configSource: "Init(libPath)",
+		candidates: []libraryCandidate{
+			{path: "./shim/target/debug/libchroma_go_shim", source: "configured"},
+			{path: "./shim/target/debug/libchroma_go_shim.so", source: "derived:added-extension"},
+		},
+		warnings: []string{"skipped absolute fallback for [configured] \"./shim/target/debug/libchroma_go_shim\": cwd unavailable"},
+	}
+
+	err := formatLibraryLoadError(plan, []string{
+		"[configured] ./shim/target/debug/libchroma_go_shim (not found)",
+		"[derived:added-extension] ./shim/target/debug/libchroma_go_shim.so (not found)",
+	})
+	msg := err.Error()
+
+	if !strings.Contains(msg, "[configured] ./shim/target/debug/libchroma_go_shim") {
+		t.Fatalf("expected error to include configured candidate marker, got: %q", msg)
+	}
+	if !strings.Contains(msg, "[derived:added-extension]") {
+		t.Fatalf("expected error to include derived candidate marker, got: %q", msg)
+	}
+	if !strings.Contains(msg, "path resolution warnings") {
+		t.Fatalf("expected error to include warnings section, got: %q", msg)
+	}
+}
+
+func TestCandidateSetDeduplicatesAndSkipsEmptyValues(t *testing.T) {
+	set := newCandidateSet(4)
+	set.add("", "configured")
+	set.add("   ", "configured")
+	set.add("/tmp/libchroma_go_shim.so", "configured")
+	set.add("/tmp/libchroma_go_shim.so", "derived:added-extension")
+
+	got := set.candidates()
+	if len(got) != 1 {
+		t.Fatalf("expected one deduplicated candidate, got %#v", got)
+	}
+	if got[0].source != "configured" {
+		t.Fatalf("expected first source to be retained on duplicate add, got %#v", got[0])
+	}
+}
+
+func TestBuildLibraryPathCandidatesLibPrefixedInputDoesNotDoublePrefix(t *testing.T) {
+	got, warnings := buildLibraryPathCandidates("/tmp/libchroma_go_shim", "linux", notFoundStat)
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for lib-prefixed input, got %#v", warnings)
+	}
+	if containsCandidatePath(got, "/tmp/liblibchroma_go_shim.so") {
+		t.Fatalf("did not expect double-lib candidate, got %#v", got)
+	}
+}
+
+func TestBuildLibraryPathCandidatesOrdering(t *testing.T) {
+	got, warnings := buildLibraryPathCandidates("/tmp/chroma_go_shim", "linux", notFoundStat)
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %#v", warnings)
+	}
+	if len(got) < 3 {
+		t.Fatalf("expected at least 3 candidates, got %#v", got)
+	}
+
+	wantOrder := []string{
+		"/tmp/chroma_go_shim",
+		"/tmp/chroma_go_shim.so",
+		"/tmp/libchroma_go_shim.so",
+	}
+	for i, want := range wantOrder {
+		if got[i].path != want {
+			t.Fatalf("expected candidate[%d]=%q, got %#v", i, want, got)
+		}
+	}
+}
+
+func TestAppendAbsolutePathCandidatesOrdering(t *testing.T) {
+	base := []libraryCandidate{
+		{path: "shim/a", source: "configured"},
+		{path: "shim/b.so", source: "derived:added-extension"},
+	}
+	abs := func(path string) (string, error) {
+		return "/abs/" + path, nil
+	}
+
+	got, warnings := appendAbsolutePathCandidates(base, "linux", abs)
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %#v", warnings)
+	}
+
+	wantOrder := []string{
+		"shim/a",
+		"shim/b.so",
+		"/abs/shim/a",
+		"/abs/shim/b.so",
+	}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("expected %d candidates, got %#v", len(wantOrder), got)
+	}
+	for i, want := range wantOrder {
+		if got[i].path != want {
+			t.Fatalf("expected candidate[%d]=%q, got %#v", i, want, got)
+		}
+	}
+}
+
+func TestJoinPathForOSHandlesRootDirectories(t *testing.T) {
+	if got := joinPathForOS("/", "libchroma_go_shim.so", "linux"); got != "/libchroma_go_shim.so" {
+		t.Fatalf("expected unix root join to preserve root, got %q", got)
+	}
+	if got := joinPathForOS(`\`, "chroma_go_shim.dll", "windows"); got != `\chroma_go_shim.dll` {
+		t.Fatalf("expected windows root join to preserve root, got %q", got)
+	}
+}

--- a/library_unix.go
+++ b/library_unix.go
@@ -3,23 +3,33 @@
 package chroma
 
 import (
+	"os"
+	"runtime"
+
 	"github.com/ebitengine/purego"
-	"github.com/pkg/errors"
 )
 
 func loadLibrary(path string) (uintptr, error) {
-	resolvedPath, err := resolveLibraryPath(path)
+	plan, err := resolveLibraryLoadPlan(path, runtime.GOOS, os.Getenv, os.Stat)
 	if err != nil {
 		return 0, err
 	}
 
-	libHandle, err := purego.Dlopen(resolvedPath, purego.RTLD_NOW|purego.RTLD_GLOBAL)
-	if err != nil {
-		return 0, errors.Wrapf(err, "failed to load library: %s", resolvedPath)
-	}
-	if libHandle == 0 {
-		return 0, errors.Errorf("failed to load library: %s", resolvedPath)
+	loadAttempts := make([]string, 0, len(plan.candidates))
+	for _, candidate := range plan.candidates {
+		libHandle, loadErr := purego.Dlopen(candidate.path, purego.RTLD_NOW|purego.RTLD_GLOBAL)
+		if loadErr == nil {
+			if libHandle != 0 {
+				// Successful load returns only the handle; plan warnings are intentionally
+				// surfaced only on error to preserve the current Init/loadLibrary API.
+				return libHandle, nil
+			}
+
+			loadAttempts = append(loadAttempts, formatLoadAttempt(candidate, nil))
+			return 0, formatLibraryLoadError(plan, loadAttempts)
+		}
+		loadAttempts = append(loadAttempts, formatLoadAttempt(candidate, loadErr))
 	}
 
-	return libHandle, nil
+	return 0, formatLibraryLoadError(plan, loadAttempts)
 }

--- a/library_windows.go
+++ b/library_windows.go
@@ -3,19 +3,33 @@
 package chroma
 
 import (
-	"github.com/pkg/errors"
+	"os"
+	"runtime"
+
 	"golang.org/x/sys/windows"
 )
 
 func loadLibrary(path string) (uintptr, error) {
-	resolvedPath, err := resolveLibraryPath(path)
+	plan, err := resolveLibraryLoadPlan(path, runtime.GOOS, os.Getenv, os.Stat)
 	if err != nil {
 		return 0, err
 	}
 
-	handle, err := windows.LoadLibrary(resolvedPath)
-	if err != nil {
-		return 0, errors.Wrapf(err, "failed to load library: %s", resolvedPath)
+	loadAttempts := make([]string, 0, len(plan.candidates))
+	for _, candidate := range plan.candidates {
+		handle, loadErr := windows.LoadLibrary(candidate.path)
+		if loadErr == nil {
+			if handle != 0 {
+				// Successful load returns only the handle; plan warnings are intentionally
+				// surfaced only on error to preserve the current Init/loadLibrary API.
+				return uintptr(handle), nil
+			}
+
+			loadAttempts = append(loadAttempts, formatLoadAttempt(candidate, nil))
+			return 0, formatLibraryLoadError(plan, loadAttempts)
+		}
+		loadAttempts = append(loadAttempts, formatLoadAttempt(candidate, loadErr))
 	}
-	return uintptr(handle), nil
+
+	return 0, formatLibraryLoadError(plan, loadAttempts)
 }


### PR DESCRIPTION
## Summary
- harden loader path resolution with OS-aware candidate generation, source provenance tagging, and aggregated diagnostics
- add absolute fallback handling and stat-based warnings for directory inference edge cases
- fail fast on anomalous loader state (nil error + zero handle) and unify Unix/Windows error behavior
- add comprehensive loader tests for extensions, separators, root paths, ordering, deduplication, and warning paths

## Validation
- make test
- make lint

Closes #4