### PR TITLE
Refocus local-go-chroma boundary and harden polling tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ It supports both:
 - Rust 1.70+
 - `golangci-lint` (for `lint` checks)
 
+## Integration Direction (`chroma-go` PersistentClient)
+
+This repository is the low-level runtime layer (`purego` + Rust shim). It is intended to be consumed by `github.com/amikos-tech/chroma-go` for a downstream `PersistentClient`.
+
+Design intent:
+
+- `local-go-chroma` remains independent and does not import `chroma-go`
+- `chroma-go` depends on `local-go-chroma` to embed Chroma in Go apps
+- integration and compatibility tests for `PersistentClient` should live in `chroma-go`
+
 ## Building
 
 ```bash

--- a/chroma_test.go
+++ b/chroma_test.go
@@ -1,10 +1,13 @@
 package chroma
 
 import (
+	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestInitAndVersion(t *testing.T) {
@@ -47,19 +50,15 @@ allow_reset: true
 		t.Errorf("Expected address 127.0.0.1, got %s", server.Address())
 	}
 
-	// Give the server time to start
-	time.Sleep(2 * time.Second)
-
-	// Try to connect to the server
-	resp, err := http.Get("http://127.0.0.1:8765/api/v2/heartbeat")
-	if err != nil {
-		t.Fatalf("Failed to connect to server: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("Expected status 200, got %d", resp.StatusCode)
-	}
+	require.Eventually(t, func() bool {
+		resp, err := http.Get("http://127.0.0.1:8765/api/v2/heartbeat")
+		if err != nil {
+			return false
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 10*time.Second, 100*time.Millisecond, "server heartbeat did not become ready")
 
 	t.Log("Server is running and responding to heartbeat")
 }
@@ -133,17 +132,15 @@ func TestNewServerWithOptions(t *testing.T) {
 		t.Errorf("Expected port 8766, got %d", server.Port())
 	}
 
-	time.Sleep(2 * time.Second)
-
-	resp, err := http.Get("http://127.0.0.1:8766/api/v2/heartbeat")
-	if err != nil {
-		t.Fatalf("Failed to connect to server: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("Expected status 200, got %d", resp.StatusCode)
-	}
+	require.Eventually(t, func() bool {
+		resp, err := http.Get("http://127.0.0.1:8766/api/v2/heartbeat")
+		if err != nil {
+			return false
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 10*time.Second, 100*time.Millisecond, "server heartbeat did not become ready")
 
 	t.Log("NewServer with options is working")
 }

--- a/embedded_integration_edge_test.go
+++ b/embedded_integration_edge_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func newEmbeddedForIntegrationTest(t *testing.T) *Embedded {
@@ -126,22 +128,12 @@ func TestEmbeddedDeleteByDocumentFilterOnly(t *testing.T) {
 		t.Fatalf("DeleteRecords by filter failed: %v", err)
 	}
 
-	deadline := time.Now().Add(5 * time.Second)
 	var count uint32
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		count, err = embedded.CountRecords(EmbeddedCountRecordsRequest{
 			CollectionID: collection.ID,
 			DatabaseName: databaseName,
 		})
-		if err == nil && count == 1 {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if err != nil {
-		t.Fatalf("CountRecords failed: %v", err)
-	}
-	if count != 1 {
-		t.Fatalf("expected 1 record after filtered delete, got %d", count)
-	}
+		return err == nil && count == 1
+	}, 5*time.Second, 100*time.Millisecond, "CountRecords did not reach expected count after filtered delete")
 }

--- a/embedded_test.go
+++ b/embedded_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestEmbeddedModeBasicFlow(t *testing.T) {
@@ -240,23 +242,13 @@ func TestEmbeddedModeBasicFlow(t *testing.T) {
 	}
 
 	var recordCount uint32
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		recordCount, err = embedded.CountRecords(EmbeddedCountRecordsRequest{
 			CollectionID: collection.ID,
 			DatabaseName: databaseName,
 		})
-		if err == nil && recordCount == 2 {
-			break
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	if err != nil {
-		t.Fatalf("CountRecords failed: %v", err)
-	}
-	if recordCount != 2 {
-		t.Fatalf("expected 2 records, got %d", recordCount)
-	}
+		return err == nil && recordCount == 2
+	}, 5*time.Second, 200*time.Millisecond, "CountRecords did not reach expected value after add")
 
 	getResp, err := embedded.GetRecords(EmbeddedGetRecordsRequest{
 		CollectionID: collection.ID,
@@ -284,25 +276,15 @@ func TestEmbeddedModeBasicFlow(t *testing.T) {
 		t.Fatalf("UpdateRecords failed: %v", err)
 	}
 
-	deadline = time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		getResp, err = embedded.GetRecords(EmbeddedGetRecordsRequest{
 			CollectionID: collection.ID,
 			DatabaseName: databaseName,
 			IDs:          []string{"doc-1"},
 			Include:      []string{"documents"},
 		})
-		if err == nil && len(getResp.Documents) == 1 && getResp.Documents[0] != nil && *getResp.Documents[0] == "first-updated" {
-			break
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	if err != nil {
-		t.Fatalf("GetRecords after update failed: %v", err)
-	}
-	if len(getResp.Documents) != 1 || getResp.Documents[0] == nil || *getResp.Documents[0] != "first-updated" {
-		t.Fatalf("expected updated document first-updated, got %#v", getResp.Documents)
-	}
+		return err == nil && len(getResp.Documents) == 1 && getResp.Documents[0] != nil && *getResp.Documents[0] == "first-updated"
+	}, 5*time.Second, 200*time.Millisecond, "GetRecords did not return updated document")
 
 	err = embedded.UpsertRecords(EmbeddedUpsertRecordsRequest{
 		CollectionID: collection.ID,
@@ -315,23 +297,13 @@ func TestEmbeddedModeBasicFlow(t *testing.T) {
 		t.Fatalf("UpsertRecords failed: %v", err)
 	}
 
-	deadline = time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		recordCount, err = embedded.CountRecords(EmbeddedCountRecordsRequest{
 			CollectionID: collection.ID,
 			DatabaseName: databaseName,
 		})
-		if err == nil && recordCount == 3 {
-			break
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	if err != nil {
-		t.Fatalf("CountRecords after upsert failed: %v", err)
-	}
-	if recordCount != 3 {
-		t.Fatalf("expected 3 records after upsert, got %d", recordCount)
-	}
+		return err == nil && recordCount == 3
+	}, 5*time.Second, 200*time.Millisecond, "CountRecords did not reach expected value after upsert")
 
 	indexingStatus, err := embedded.IndexingStatus(EmbeddedIndexingStatusRequest{
 		CollectionID: collection.ID,
@@ -356,50 +328,27 @@ func TestEmbeddedModeBasicFlow(t *testing.T) {
 		t.Fatalf("DeleteRecords failed: %v", err)
 	}
 
-	deadline = time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		recordCount, err = embedded.CountRecords(EmbeddedCountRecordsRequest{
 			CollectionID: collection.ID,
 			DatabaseName: databaseName,
 		})
-		if err == nil && recordCount == 2 {
-			break
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	if err != nil {
-		t.Fatalf("CountRecords after delete failed: %v", err)
-	}
-	if recordCount != 2 {
-		t.Fatalf("expected 2 records after delete, got %d", recordCount)
-	}
+		return err == nil && recordCount == 2
+	}, 5*time.Second, 200*time.Millisecond, "CountRecords did not reach expected value after delete")
 
 	var queryResp *EmbeddedQueryResponse
-	deadline = time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		queryResp, err = embedded.Query(EmbeddedQueryRequest{
 			CollectionID:    collection.ID,
 			DatabaseName:    databaseName,
 			QueryEmbeddings: [][]float32{{0.1, 0.2, 0.3}},
 			NResults:        1,
 		})
-		if err == nil && len(queryResp.IDs) > 0 && len(queryResp.IDs[0]) > 0 {
-			break
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	if err != nil {
-		t.Fatalf("Query failed: %v", err)
-	}
-	if queryResp == nil || len(queryResp.IDs) == 0 || len(queryResp.IDs[0]) == 0 {
-		t.Fatal("query returned no ids")
-	}
-	if queryResp.IDs[0][0] != "doc-1" {
-		t.Fatalf("expected top match doc-1, got %q", queryResp.IDs[0][0])
-	}
+		return err == nil && queryResp != nil && len(queryResp.IDs) > 0 && len(queryResp.IDs[0]) > 0
+	}, 5*time.Second, 200*time.Millisecond, "Query did not return IDs")
+	require.Equal(t, "doc-1", queryResp.IDs[0][0])
 
-	deadline = time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		queryResp, err = embedded.Query(EmbeddedQueryRequest{
 			CollectionID:    collection.ID,
 			DatabaseName:    databaseName,
@@ -409,20 +358,11 @@ func TestEmbeddedModeBasicFlow(t *testing.T) {
 				"$contains": "updated",
 			},
 		})
-		if err == nil && len(queryResp.IDs) > 0 && len(queryResp.IDs[0]) > 0 {
-			break
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	if err != nil {
-		t.Fatalf("Query with where_document failed: %v", err)
-	}
-	if queryResp.IDs[0][0] != "doc-1" {
-		t.Fatalf("expected filtered top match doc-1, got %q", queryResp.IDs[0][0])
-	}
+		return err == nil && queryResp != nil && len(queryResp.IDs) > 0 && len(queryResp.IDs[0]) > 0
+	}, 5*time.Second, 200*time.Millisecond, "Query with where_document did not return IDs")
+	require.Equal(t, "doc-1", queryResp.IDs[0][0])
 
-	deadline = time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		getResp, err = embedded.GetRecords(EmbeddedGetRecordsRequest{
 			CollectionID: collection.ID,
 			DatabaseName: databaseName,
@@ -431,17 +371,9 @@ func TestEmbeddedModeBasicFlow(t *testing.T) {
 			},
 			Include: []string{"documents"},
 		})
-		if err == nil && len(getResp.IDs) > 0 {
-			break
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	if err != nil {
-		t.Fatalf("GetRecords with where_document failed: %v", err)
-	}
-	if len(getResp.IDs) == 0 || getResp.IDs[0] != "doc-1" {
-		t.Fatalf("expected filtered get to return doc-1, got %#v", getResp.IDs)
-	}
+		return err == nil && len(getResp.IDs) > 0
+	}, 5*time.Second, 200*time.Millisecond, "GetRecords with where_document did not return IDs")
+	require.Equal(t, "doc-1", getResp.IDs[0])
 
 	err = embedded.DeleteRecords(EmbeddedDeleteRecordsRequest{
 		CollectionID: collection.ID,
@@ -454,23 +386,13 @@ func TestEmbeddedModeBasicFlow(t *testing.T) {
 		t.Fatalf("DeleteRecords with where_document failed: %v", err)
 	}
 
-	deadline = time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		recordCount, err = embedded.CountRecords(EmbeddedCountRecordsRequest{
 			CollectionID: collection.ID,
 			DatabaseName: databaseName,
 		})
-		if err == nil && recordCount == 1 {
-			break
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	if err != nil {
-		t.Fatalf("CountRecords after filter delete failed: %v", err)
-	}
-	if recordCount != 1 {
-		t.Fatalf("expected 1 record after filter delete, got %d", recordCount)
-	}
+		return err == nil && recordCount == 1
+	}, 5*time.Second, 200*time.Millisecond, "CountRecords did not reach expected value after filter delete")
 
 	if err := embedded.Reset(); err != nil {
 		t.Fatalf("Reset failed: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/amikos-tech/local-go-chroma
 
-go 1.25.5
+go 1.21
 
 require (
 	github.com/ebitengine/purego v0.9.1
@@ -9,5 +9,12 @@ require (
 
 require (
 	github.com/leanovate/gopter v0.2.11
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.6.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,7 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ebitengine/purego v0.9.1 h1:a/k2f2HQU3Pi399RPW1MOaZyhKJL9w/xFpKAg4q1s0A=
 github.com/ebitengine/purego v0.9.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
@@ -170,8 +171,10 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzWu4=
 github.com/leanovate/gopter v0.2.11/go.mod h1:aK3tzZP/C+p1m3SPRE4SYZFGP7jjkuSI4f7Xvpt0S9c=
@@ -198,6 +201,7 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -228,6 +232,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -587,6 +593,7 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
@@ -596,6 +603,8 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
## Summary
- clarify project boundary in README: `local-go-chroma` is the low-level runtime layer intended to be consumed by `chroma-go` for a future `PersistentClient`
- keep this repo independent of `chroma-go` by removing reverse coupling and setting module baseline to `go 1.21`
- replace sleep-based waits in tests with `require.Eventually` for deterministic, CI-friendly polling
- remove redundant post-Eventually assertions and drain heartbeat response bodies in polling checks

## Validation
- make test
- make lint
