### PR TITLE
Fix #35: align UpdateCollection metadata semantics and coverage

### DIFF
--- a/GO_API_SURFACE.md
+++ b/GO_API_SURFACE.md
@@ -233,7 +233,7 @@ fmt.Println("database:", db.Name)
 `EmbeddedUpdateCollectionRequest` fields:
 - `CollectionID`
 - `NewName` (optional)
-- `NewMetadata map[string]any` (optional; nil values delete keys)
+- `NewMetadata map[string]any` (optional; replaces existing collection metadata; nil values are rejected)
 - `DatabaseName` (optional)
 
 At least one of `NewName` or `NewMetadata` is required.
@@ -271,7 +271,6 @@ _ = embedded.UpdateCollection(chroma.EmbeddedUpdateCollectionRequest{
     CollectionID: col.ID,
     NewMetadata: map[string]any{
         "owner": "platform",
-        "deprecated_field": nil, // delete key
     },
     DatabaseName: "my_db",
 })

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ fmt.Println(result.IDs)
 `EmbeddedUpdateCollectionRequest` fields:
 - `CollectionID`
 - `NewName` (optional)
-- `NewMetadata` (optional; nil values delete metadata keys)
+- `NewMetadata` (optional; replaces existing collection metadata; nil values are rejected)
 - `DatabaseName` (optional)
 
 At least one of `NewName` or `NewMetadata` is required.

--- a/embedded.go
+++ b/embedded.go
@@ -196,6 +196,8 @@ type EmbeddedCountCollectionsRequest struct {
 }
 
 // EmbeddedUpdateCollectionRequest updates collection properties.
+// NewMetadata replaces the entire existing collection metadata
+// (keys not present in NewMetadata are removed; nil values are not permitted).
 type EmbeddedUpdateCollectionRequest struct {
 	CollectionID string         `json:"collection_id"`
 	NewName      string         `json:"new_name,omitempty"`
@@ -872,7 +874,7 @@ func (e *Embedded) UpdateCollection(request EmbeddedUpdateCollectionRequest) err
 
 	requestPayload := request
 	if hasNewMetadata {
-		normalizedMetadata, err := validateAndNormalizeMetadata(request.NewMetadata, true)
+		normalizedMetadata, err := validateAndNormalizeMetadata(request.NewMetadata, false)
 		if err != nil {
 			return errors.Wrap(err, "invalid new_metadata")
 		}

--- a/embedded_integration_edge_test.go
+++ b/embedded_integration_edge_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	collectionEventuallyTimeout      = 5 * time.Second
+	collectionEventuallyPollInterval = 100 * time.Millisecond
+)
+
 func newEmbeddedForIntegrationTest(t *testing.T) *Embedded {
 	t.Helper()
 
@@ -29,6 +34,52 @@ func newEmbeddedForIntegrationTest(t *testing.T) *Embedded {
 		}
 	})
 	return embedded
+}
+
+func isRetriableGetCollectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
+}
+
+func waitForCollectionConvergence(
+	t *testing.T,
+	embedded *Embedded,
+	request EmbeddedGetCollectionRequest,
+	description string,
+	predicate func(*EmbeddedCollection) (bool, error),
+) {
+	t.Helper()
+
+	var lastMetadata map[string]any
+	var lastErr error
+	var hardErr error
+
+	require.Eventually(t, func() bool {
+		updated, getErr := embedded.GetCollection(request)
+		if getErr != nil {
+			if isRetriableGetCollectionError(getErr) {
+				lastErr = getErr
+				return false
+			}
+			hardErr = getErr
+			return true
+		}
+		lastErr = nil
+		lastMetadata = updated.Metadata
+
+		done, predicateErr := predicate(updated)
+		if predicateErr != nil {
+			hardErr = predicateErr
+			return true
+		}
+		return done
+	}, collectionEventuallyTimeout, collectionEventuallyPollInterval, "%s did not converge (last metadata=%#v, last err=%v)", description, lastMetadata, lastErr)
+
+	if hardErr != nil {
+		t.Fatalf("%s failed with non-retriable error: %v (last metadata=%#v, last err=%v)", description, hardErr, lastMetadata, lastErr)
+	}
 }
 
 func TestEmbeddedWhereValidationEdgeCases(t *testing.T) {
@@ -158,15 +209,15 @@ func TestEmbeddedCreateCollectionRejectsInvalidConfigurationIntegration(t *testi
 	require.Contains(t, strings.ToLower(err.Error()), "invalid configuration")
 }
 
-func TestEmbeddedUpdateCollectionMetadataKeyDeletionRoundTrip(t *testing.T) {
+func TestEmbeddedUpdateCollectionMetadataUsesReplacementSemantics(t *testing.T) {
 	embedded := newEmbeddedForIntegrationTest(t)
 
-	databaseName := fmt.Sprintf("update_meta_delete_db_%d", time.Now().UnixNano())
+	databaseName := fmt.Sprintf("update_meta_replace_db_%d", time.Now().UnixNano())
 	if err := embedded.CreateDatabase(EmbeddedCreateDatabaseRequest{Name: databaseName}); err != nil {
 		t.Fatalf("CreateDatabase failed: %v", err)
 	}
 
-	collectionName := fmt.Sprintf("update_meta_delete_collection_%d", time.Now().UnixNano())
+	collectionName := fmt.Sprintf("update_meta_replace_collection_%d", time.Now().UnixNano())
 	collection, err := embedded.CreateCollection(EmbeddedCreateCollectionRequest{
 		Name:         collectionName,
 		DatabaseName: databaseName,
@@ -185,30 +236,205 @@ func TestEmbeddedUpdateCollectionMetadataKeyDeletionRoundTrip(t *testing.T) {
 		CollectionID: collection.ID,
 		DatabaseName: databaseName,
 		NewMetadata: map[string]any{
-			"drop": nil,
+			"replacement": "yes",
 		},
 	})
 	if err != nil {
-		t.Fatalf("UpdateCollection metadata deletion failed: %v", err)
+		t.Fatalf("UpdateCollection metadata replacement failed: %v", err)
 	}
 
-	var lastMetadata map[string]any
-	var lastErr error
-	require.Eventually(t, func() bool {
-		updated, getErr := embedded.GetCollection(EmbeddedGetCollectionRequest{
+	waitForCollectionConvergence(
+		t,
+		embedded,
+		EmbeddedGetCollectionRequest{
 			Name:         collectionName,
 			DatabaseName: databaseName,
-		})
-		if getErr != nil {
-			lastErr = getErr
-			return false
-		}
-		lastErr = nil
-		lastMetadata = updated.Metadata
-		if updated.Metadata == nil {
-			return true
-		}
-		_, exists := updated.Metadata["drop"]
-		return !exists
-	}, 5*time.Second, 100*time.Millisecond, "collection metadata key deletion did not converge (last metadata=%#v, last err=%v)", lastMetadata, lastErr)
+		},
+		"collection metadata replacement",
+		func(updated *EmbeddedCollection) (bool, error) {
+			if updated.Metadata == nil {
+				return false, nil
+			}
+
+			replacement, replacementExists := updated.Metadata["replacement"]
+			if !replacementExists {
+				return false, nil
+			}
+			replacementValue, replacementIsString := replacement.(string)
+			if !replacementIsString {
+				return false, fmt.Errorf("expected metadata[replacement] to be string, got %T", replacement)
+			}
+
+			_, keepExists := updated.Metadata["keep"]
+			_, dropExists := updated.Metadata["drop"]
+			return replacementValue == "yes" && !keepExists && !dropExists, nil
+		},
+	)
+}
+
+func TestEmbeddedUpdateCollectionMetadataReplacementWithOverlappingKey(t *testing.T) {
+	embedded := newEmbeddedForIntegrationTest(t)
+
+	databaseName := fmt.Sprintf("update_meta_overlap_db_%d", time.Now().UnixNano())
+	if err := embedded.CreateDatabase(EmbeddedCreateDatabaseRequest{Name: databaseName}); err != nil {
+		t.Fatalf("CreateDatabase failed: %v", err)
+	}
+
+	collectionName := fmt.Sprintf("update_meta_overlap_collection_%d", time.Now().UnixNano())
+	collection, err := embedded.CreateCollection(EmbeddedCreateCollectionRequest{
+		Name:         collectionName,
+		DatabaseName: databaseName,
+		Metadata: map[string]any{
+			"owner":   "qa",
+			"version": "v1",
+			"drop":    "remove-me",
+		},
+		GetOrCreate: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection failed: %v", err)
+	}
+	require.Contains(t, collection.Metadata, "owner")
+	require.Contains(t, collection.Metadata, "version")
+	require.Contains(t, collection.Metadata, "drop")
+
+	err = embedded.UpdateCollection(EmbeddedUpdateCollectionRequest{
+		CollectionID: collection.ID,
+		DatabaseName: databaseName,
+		NewMetadata: map[string]any{
+			"owner": "platform",
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateCollection metadata replacement failed: %v", err)
+	}
+
+	waitForCollectionConvergence(
+		t,
+		embedded,
+		EmbeddedGetCollectionRequest{
+			Name:         collectionName,
+			DatabaseName: databaseName,
+		},
+		"collection metadata overlapping replacement",
+		func(updated *EmbeddedCollection) (bool, error) {
+			if updated.Metadata == nil {
+				return false, nil
+			}
+
+			owner, ownerExists := updated.Metadata["owner"]
+			if !ownerExists {
+				return false, nil
+			}
+			ownerValue, ownerIsString := owner.(string)
+			if !ownerIsString {
+				return false, fmt.Errorf("expected metadata[owner] to be string, got %T", owner)
+			}
+
+			_, versionExists := updated.Metadata["version"]
+			_, dropExists := updated.Metadata["drop"]
+			return ownerValue == "platform" && !versionExists && !dropExists, nil
+		},
+	)
+}
+
+func TestEmbeddedUpdateCollectionNameAndMetadataTogether(t *testing.T) {
+	embedded := newEmbeddedForIntegrationTest(t)
+
+	databaseName := fmt.Sprintf("update_name_meta_db_%d", time.Now().UnixNano())
+	if err := embedded.CreateDatabase(EmbeddedCreateDatabaseRequest{Name: databaseName}); err != nil {
+		t.Fatalf("CreateDatabase failed: %v", err)
+	}
+
+	collectionName := fmt.Sprintf("update_name_meta_collection_%d", time.Now().UnixNano())
+	collection, err := embedded.CreateCollection(EmbeddedCreateCollectionRequest{
+		Name:         collectionName,
+		DatabaseName: databaseName,
+		Metadata: map[string]any{
+			"owner":   "qa",
+			"drop":    "remove-me",
+			"version": "v1",
+		},
+		GetOrCreate: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection failed: %v", err)
+	}
+
+	renamedCollectionName := fmt.Sprintf("%s_renamed", collectionName)
+	err = embedded.UpdateCollection(EmbeddedUpdateCollectionRequest{
+		CollectionID: collection.ID,
+		NewName:      renamedCollectionName,
+		DatabaseName: databaseName,
+		NewMetadata: map[string]any{
+			"owner":    "platform",
+			"active":   true,
+			"priority": 3,
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateCollection name+metadata failed: %v", err)
+	}
+
+	waitForCollectionConvergence(
+		t,
+		embedded,
+		EmbeddedGetCollectionRequest{
+			Name:         renamedCollectionName,
+			DatabaseName: databaseName,
+		},
+		"collection name+metadata replacement",
+		func(updated *EmbeddedCollection) (bool, error) {
+			if updated.Metadata == nil {
+				return false, nil
+			}
+
+			owner, ownerExists := updated.Metadata["owner"]
+			if !ownerExists {
+				return false, nil
+			}
+			ownerValue, ownerIsString := owner.(string)
+			if !ownerIsString {
+				return false, fmt.Errorf("expected metadata[owner] to be string, got %T", owner)
+			}
+			if ownerValue != "platform" {
+				return false, nil
+			}
+
+			active, activeExists := updated.Metadata["active"]
+			if !activeExists {
+				return false, nil
+			}
+			activeValue, activeIsBool := active.(bool)
+			if !activeIsBool {
+				return false, fmt.Errorf("expected metadata[active] to be bool, got %T", active)
+			}
+			if !activeValue {
+				return false, nil
+			}
+
+			priority, priorityExists := updated.Metadata["priority"]
+			if !priorityExists {
+				return false, nil
+			}
+			priorityIsThree := false
+			switch v := priority.(type) {
+			case float64:
+				priorityIsThree = v == 3
+			case int64:
+				priorityIsThree = v == 3
+			case int:
+				priorityIsThree = v == 3
+			default:
+				return false, fmt.Errorf("expected metadata[priority] to be numeric, got %T", priority)
+			}
+			if !priorityIsThree {
+				return false, nil
+			}
+
+			_, dropExists := updated.Metadata["drop"]
+			_, versionExists := updated.Metadata["version"]
+			return !dropExists && !versionExists, nil
+		},
+	)
 }

--- a/embedded_metadata_validation_test.go
+++ b/embedded_metadata_validation_test.go
@@ -241,6 +241,21 @@ func TestUpdateCollectionRejectsInvalidNewMetadata(t *testing.T) {
 	require.Contains(t, err.Error(), "nested objects are not supported")
 }
 
+func TestUpdateCollectionRejectsNilNewMetadataValues(t *testing.T) {
+	fakeEmbedded := &Embedded{handle: 1}
+
+	err := fakeEmbedded.UpdateCollection(EmbeddedUpdateCollectionRequest{
+		CollectionID: "collection-id",
+		NewMetadata: map[string]any{
+			"deprecated": nil,
+		},
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid new_metadata")
+	require.Contains(t, err.Error(), "cannot be null")
+}
+
 func TestUpdateCollectionValidNewMetadataIsSerialized(t *testing.T) {
 	originalUpdate := chromaEmbeddedUpdateCollection
 	defer func() { chromaEmbeddedUpdateCollection = originalUpdate }()
@@ -255,10 +270,9 @@ func TestUpdateCollectionValidNewMetadataIsSerialized(t *testing.T) {
 	err := embedded.UpdateCollection(EmbeddedUpdateCollectionRequest{
 		CollectionID: "00000000-0000-0000-0000-000000000001",
 		NewMetadata: map[string]any{
-			"owner":      "qa",
-			"score":      1.0,
-			"levels":     []int{1, 2},
-			"deprecated": nil,
+			"owner":  "qa",
+			"score":  1.0,
+			"levels": []int{1, 2},
 		},
 	})
 	require.NoError(t, err)
@@ -279,10 +293,6 @@ func TestUpdateCollectionValidNewMetadataIsSerialized(t *testing.T) {
 	levels, ok := levelsRaw.([]any)
 	require.True(t, ok)
 	require.Equal(t, []any{1.0, 2.0}, levels)
-
-	deprecated, ok := payload.NewMetadata["deprecated"]
-	require.True(t, ok)
-	require.Nil(t, deprecated)
 }
 
 func TestCreateCollectionValidMetadataIsSerialized(t *testing.T) {

--- a/embedded_property_test.go
+++ b/embedded_property_test.go
@@ -267,7 +267,7 @@ func TestEmbeddedValidationProperties(t *testing.T) {
 		gen.Float64Range(-1e6, 1e6),
 	))
 
-	properties.Property("Metadata normalization allows nil values for updates", prop.ForAll(
+	properties.Property("Record metadata normalization allows nil values for update/upsert payloads", prop.ForAll(
 		func(key string) bool {
 			if strings.TrimSpace(key) == "" {
 				key = "k"
@@ -276,6 +276,19 @@ func TestEmbeddedValidationProperties(t *testing.T) {
 				{key: nil},
 			}, true)
 			return err == nil
+		},
+		gen.AnyString(),
+	))
+
+	properties.Property("Collection metadata normalization rejects nil values", prop.ForAll(
+		func(key string) bool {
+			if strings.TrimSpace(key) == "" {
+				key = "k"
+			}
+			_, err := validateAndNormalizeMetadata(map[string]any{
+				key: nil,
+			}, false)
+			return err != nil && strings.Contains(err.Error(), "cannot be null")
 		},
 		gen.AnyString(),
 	))

--- a/shim/src/lib.rs
+++ b/shim/src/lib.rs
@@ -721,6 +721,8 @@ impl EmbeddedUpdateCollectionPayload {
         if self.new_name.is_none() && self.new_metadata.is_none() {
             return Err("at least one of new_name or new_metadata is required".to_string());
         }
+        // TODO: Reject null-valued metadata entries at the shim boundary for defense in depth
+        // across non-Go bindings. The Go API validates and rejects these before FFI.
         let new_metadata = self
             .new_metadata
             .map(CollectionMetadataUpdate::UpdateMetadata);
@@ -3245,6 +3247,8 @@ allow_reset: true
 
     #[test]
     fn test_update_collection_payload_accepts_new_metadata_without_name() {
+        // This validates raw shim payload parsing only.
+        // The Go API rejects null-valued entries in new_metadata before reaching FFI.
         let payload: EmbeddedUpdateCollectionPayload = serde_json::from_value(json!({
             "collection_id": "00000000-0000-0000-0000-000000000001",
             "new_metadata": {


### PR DESCRIPTION
## Summary
- clarify collection `UpdateCollection.NewMetadata` semantics as full replacement in docs and API comments
- enforce nil-value rejection for collection metadata updates in Go validation (`invalid new_metadata: metadata.<key> cannot be null`)
- strengthen integration coverage for replacement behavior:
  - disjoint-key replacement
  - overlapping-key replacement
  - combined `NewName` + `NewMetadata` update with typed metadata values
- improve integration test polling readability by failing fast on non-retriable errors/type mismatches
- clarify record-level property test naming and add a collection-level property test for nil rejection
- add a shim TODO to reject null-valued metadata entries at the FFI boundary for defense in depth

Closes #35.

## Validation
- attempted `make test` (blocked locally: Xcode license not accepted)
- attempted `make lint` (blocked locally: Xcode license not accepted)
- ran `CGO_ENABLED=0 CHROMA_LIB_PATH=/Users/tazarov/experiments/amikos/local-go-chroma/shim/target/debug/libchroma_go_shim.dylib go test -v ./...`
- ran `CGO_ENABLED=0 golangci-lint run ./...`
