### PR TITLE
Pin shim hnswlib lock to 312991c (match rust/python_bindings)

### DIFF
--- a/shim/Cargo.lock
+++ b/shim/Cargo.lock
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "hnswlib"
 version = "0.8.2"
-source = "git+https://github.com/chroma-core/hnswlib.git?branch=master#b5c642880e92063b5ddb7c364ba76d8337017f88"
+source = "git+https://github.com/chroma-core/hnswlib.git?branch=master#312991cf9e640d5ccab879906a51e7612ce6fcf1"
 dependencies = [
  "cc",
  "thiserror 1.0.69",


### PR DESCRIPTION
## Summary
- pin `shim/Cargo.lock` hnswlib source revision from `b5c642...` to `312991c...`
- align shim-native dependency resolution with the revision used in Chroma Rust workspace / python bindings

## Why
- `v0.3.2` updated Chroma crates to `1.5.2` but the checked-in shim lockfile still resolved an older hnswlib commit
- this keeps the release artifact on the old native code path and can still trigger local persistent load/integrity aborts under churn

## Change
- one-line lockfile pin in `shim/Cargo.lock`

## Validation
- Go local embedded repro with heavy restart/delete+reinsert churn no longer aborts when shim is built with this lock pin
