### PR TITLE
Add repository CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for the entire repository.
+* @tazarov


### PR DESCRIPTION
## Summary
- add a repo-wide CODEOWNERS file under .github
- assign default ownership for all paths to @tazarov

## Testing
- not run (metadata-only change)