### PR TITLE
chore(java): bump bundle version to 0.3.4

### DIFF
--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "tech.amikos"
-    version = "0.3.1-SNAPSHOT"
+    version = "0.3.4"
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## Summary
- bump the Java Gradle bundle version from 0.3.1-SNAPSHOT to 0.3.4
- align Java artifact metadata with the planned 0.3.4 release

## Testing
- not run (metadata-only change)
