### PR TITLE
feat(09): backup API for embedded and server modes

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -40,7 +40,7 @@ Java and Go APIs must provide equivalent access to all Chroma runtime capabiliti
 
 - [x] Java server lifecycle API (start/stop/port/address/URL) — Validated in Phase 7
 - [x] Java builder pattern for server configuration — Validated in Phase 6
-- [ ] Java backup API with option builder
+- [x] Java backup API with option builder — Validated in Phase 9
 - [x] Java rebuild API with option builder — Validated in Phase 8
 - [x] Java compaction API (per-collection and all) — Validated in Phase 8
 - [x] Java WAL prune API with option builder — Validated in Phase 8
@@ -62,6 +62,8 @@ The Java scaffold (v0.3.x) provides basic `ChromaRuntime` interface with `versio
 Phase 6 complete — core module now contains all shared types (7 result POJOs, 6 option/request builders, 2 config builders), FFI safety infrastructure (`AbstractChromaRuntime` with global lock), and `ServerSession` with callback slots. Backend modules (JNA, Panama) can now implement against these stable contracts.
 
 Phase 7 complete — both JNA and Panama backends retrofitted to extend `AbstractChromaRuntime`, replacing inline FFI patterns with lock-protected template methods. Server lifecycle (start/stop/close) wired through `ServerSession` with method-reference callbacks. Integration tests verify full error matrix in both backends.
+
+Phase 9 complete — backup API implemented for both embedded and server modes. Core types (BackupResult, BackupExecutor, BackupManifest) in core module, session wiring with callback slots in EmbeddedSession (8-param) and ServerSession (7-param), backend lambda construction in both JNA and Panama. 20 integration tests cover sentinel files, manifest SHA-256, options validation, and edge cases.
 
 Existing Java architecture: `core` module defines `ChromaRuntime` interface + `EmbeddedSession`, `jna` module implements via JNA, `panama` module implements via Foreign Function & Memory API. Both backends must stay in sync.
 
@@ -103,4 +105,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-03-26 after Phase 7 completion*
+*Last updated: 2026-03-27 after Phase 9 completion*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -31,9 +31,9 @@
 
 ### Backup
 
-- [ ] **BKUP-01**: `EmbeddedSession.backup(options)` performs directory copy with manifest and returns BackupManifest
-- [ ] **BKUP-02**: `ServerSession.backup(options)` performs stop-backup-restart cycle and returns BackupManifest
-- [ ] **BKUP-03**: `BackupOptions` builder supports destination, includeMetadata, leaveClosed/leaveStopped
+- [x] **BKUP-01**: `EmbeddedSession.backup(options)` performs directory copy with manifest and returns BackupManifest
+- [x] **BKUP-02**: `ServerSession.backup(options)` performs stop-backup-restart cycle and returns BackupManifest
+- [x] **BKUP-03**: `BackupOptions` builder supports destination, includeMetadata, leaveClosed/leaveStopped
 - [ ] **BKUP-04**: Integration tests verify backup creates valid output directory in both backends
 
 ### Server Maintenance
@@ -83,9 +83,9 @@
 | EMNT-03 | Phase 8 | Complete |
 | EMNT-04 | Phase 8 | Complete |
 | EMNT-05 | Phase 8 | Complete |
-| BKUP-01 | Phase 9 | Pending |
-| BKUP-02 | Phase 9 | Pending |
-| BKUP-03 | Phase 9 | Pending |
+| BKUP-01 | Phase 9 | Complete |
+| BKUP-02 | Phase 9 | Complete |
+| BKUP-03 | Phase 9 | Complete |
 | BKUP-04 | Phase 9 | Pending |
 | SMNT-01 | Phase 10 | Pending |
 | SMNT-02 | Phase 10 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -34,7 +34,7 @@
 - [x] **BKUP-01**: `EmbeddedSession.backup(options)` performs directory copy with manifest and returns BackupManifest
 - [x] **BKUP-02**: `ServerSession.backup(options)` performs stop-backup-restart cycle and returns BackupManifest
 - [x] **BKUP-03**: `BackupOptions` builder supports destination, includeMetadata, leaveClosed/leaveStopped
-- [ ] **BKUP-04**: Integration tests verify backup creates valid output directory in both backends
+- [x] **BKUP-04**: Integration tests verify backup creates valid output directory in both backends
 
 ### Server Maintenance
 
@@ -86,7 +86,7 @@
 | BKUP-01 | Phase 9 | Complete |
 | BKUP-02 | Phase 9 | Complete |
 | BKUP-03 | Phase 9 | Complete |
-| BKUP-04 | Phase 9 | Pending |
+| BKUP-04 | Phase 9 | Complete |
 | SMNT-01 | Phase 10 | Pending |
 | SMNT-02 | Phase 10 | Pending |
 | SMNT-03 | Phase 10 | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -91,10 +91,11 @@ Plans:
   2. `ServerSession.backup(options)` performs a stop-backup-restart cycle and returns a BackupManifest without corrupting the running server state
   3. `BackupOptions` builder supports destination, includeMetadata, and leaveClosed/leaveStopped flags with validation at build time
   4. Integration tests verify backup creates a valid output directory with expected contents in both JNA and Panama backends
-**Plans**: TBD
+**Plans**: 2 plans
 
 Plans:
-- [ ] 09-01: TBD
+- [ ] 09-01-PLAN.md -- Core backup types (BackupResult, BackupExecutor), session wiring, backend lambda construction
+- [ ] 09-02-PLAN.md -- Integration tests for embedded and server backup in both JNA and Panama backends
 
 ### Phase 10: Server Maintenance
 **Goal**: Users can perform rebuild, compaction, and WAL prune operations on a server-mode Chroma instance, with the server automatically stopping and restarting around each maintenance operation
@@ -126,5 +127,5 @@ Phases execute in numeric order: 6 -> 7 -> 8 -> 9 -> 10
 | 6. Core Foundation Types | v0.5.0 | 0/3 | Not started | - |
 | 7. Server Lifecycle | v0.5.0 | 2/2 | Complete | 2026-03-26 |
 | 8. Embedded Maintenance | v0.5.0 | 2/2 | Complete | 2026-03-26 |
-| 9. Backup API | v0.5.0 | 0/? | Not started | - |
+| 9. Backup API | v0.5.0 | 0/2 | Not started | - |
 | 10. Server Maintenance | v0.5.0 | 0/? | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -94,7 +94,7 @@ Plans:
 **Plans**: TBD
 
 Plans:
-- [ ] 09-01: TBD
+- [x] 09-01-PLAN.md -- BackupResult, BackupExecutor core types, session callback wiring, JNA/Panama backends
 
 ### Phase 10: Server Maintenance
 **Goal**: Users can perform rebuild, compaction, and WAL prune operations on a server-mode Chroma instance, with the server automatically stopping and restarting around each maintenance operation
@@ -126,5 +126,5 @@ Phases execute in numeric order: 6 -> 7 -> 8 -> 9 -> 10
 | 6. Core Foundation Types | v0.5.0 | 0/3 | Not started | - |
 | 7. Server Lifecycle | v0.5.0 | 2/2 | Complete | 2026-03-26 |
 | 8. Embedded Maintenance | v0.5.0 | 2/2 | Complete | 2026-03-26 |
-| 9. Backup API | v0.5.0 | 0/? | Not started | - |
+| 9. Backup API | v0.5.0 | 1/1 | Complete | 2026-03-27 |
 | 10. Server Maintenance | v0.5.0 | 0/? | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -29,7 +29,7 @@ Decimal phases appear between their surrounding integers in numeric order.
 - [ ] **Phase 6: Core Foundation Types** - Define all shared interfaces, builders, result POJOs, and FFI safety patterns in the core module with no FFI dependencies
 - [ ] **Phase 7: Server Lifecycle** - Implement server start/stop/close and connection accessors in both JNA and Panama backends
 - [ ] **Phase 8: Embedded Maintenance** - Implement rebuild, compaction, and WAL prune operations on EmbeddedSession in both backends
-- [ ] **Phase 9: Backup API** - Implement backup with filesystem copy, manifest generation, and option builder for both embedded and server modes
+- [x] **Phase 9: Backup API** - Implement backup with filesystem copy, manifest generation, and option builder for both embedded and server modes (completed 2026-03-27)
 - [ ] **Phase 10: Server Maintenance** - Implement stop-embed-op-restart orchestration for all maintenance operations on ServerSession
 
 ## Phase Details
@@ -126,5 +126,5 @@ Phases execute in numeric order: 6 -> 7 -> 8 -> 9 -> 10
 | 6. Core Foundation Types | v0.5.0 | 0/3 | Not started | - |
 | 7. Server Lifecycle | v0.5.0 | 2/2 | Complete | 2026-03-26 |
 | 8. Embedded Maintenance | v0.5.0 | 2/2 | Complete | 2026-03-26 |
-| 9. Backup API | v0.5.0 | 1/1 | Complete | 2026-03-27 |
+| 9. Backup API | v0.5.0 | 2/2 | Complete   | 2026-03-27 |
 | 10. Server Maintenance | v0.5.0 | 0/? | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v0.5.0
 milestone_name: Java API Surface
-status: Ready to plan
+status: "Phase 09 shipped — PR #81"
 stopped_at: Completed 09-02-PLAN.md
-last_updated: "2026-03-27T05:58:00.949Z"
+last_updated: "2026-03-27T10:09:58.751Z"
 progress:
   total_phases: 5
   completed_phases: 4

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v0.5.0
 milestone_name: Java API Surface
 status: "Phase 08 shipped — PR #80"
-stopped_at: Completed 08-02-PLAN.md
-last_updated: "2026-03-26T14:17:06.008Z"
+stopped_at: Phase 9 context gathered
+last_updated: "2026-03-27T05:04:36.390Z"
 progress:
   total_phases: 5
   completed_phases: 3
@@ -69,6 +69,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-03-26T13:10:41Z
-Stopped at: Completed 08-02-PLAN.md
-Resume file: None
+Last session: 2026-03-27T05:04:36.371Z
+Stopped at: Phase 9 context gathered
+Resume file: .planning/phases/09-backup-api/09-CONTEXT.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v0.5.0
 milestone_name: Java API Surface
-status: Ready to execute
+status: Ready to plan
 stopped_at: Completed 09-02-PLAN.md
-last_updated: "2026-03-27T05:52:51.230Z"
+last_updated: "2026-03-27T05:58:00.949Z"
 progress:
   total_phases: 5
   completed_phases: 4
@@ -23,8 +23,8 @@ See: .planning/PROJECT.md (updated 2026-03-21)
 
 ## Current Position
 
-Phase: 09 (backup-api) — EXECUTING
-Plan: 2 of 2
+Phase: 10
+Plan: Not started
 
 ## Performance Metrics
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v0.5.0
 milestone_name: Java API Surface
-status: "Phase 08 shipped — PR #80"
-stopped_at: Completed 08-02-PLAN.md
-last_updated: "2026-03-26T14:17:06.008Z"
+status: "Phase 09 plan 01 complete"
+stopped_at: Completed 09-01-PLAN.md
+last_updated: "2026-03-27T05:38:53Z"
 progress:
   total_phases: 5
   completed_phases: 3
-  total_plans: 7
-  completed_plans: 7
+  total_plans: 8
+  completed_plans: 8
 ---
 
 # Project State
@@ -19,12 +19,12 @@ progress:
 See: .planning/PROJECT.md (updated 2026-03-21)
 
 **Core value:** Java and Go APIs must provide equivalent access to all Chroma runtime capabilities
-**Current focus:** Phase 08 — embedded-maintenance
+**Current focus:** Phase 09 — backup-api
 
 ## Current Position
 
 Phase: 9
-Plan: Not started
+Plan: 1 of 1 complete
 
 ## Performance Metrics
 
@@ -37,6 +37,7 @@ Plan: Not started
 | 07 | 02 | 2min | 1 | 2 |
 | 08 | 01 | 3min | 2 | 4 |
 | 08 | 02 | 9min | 2 | 2 |
+| 09 | 01 | 8min | 2 | 13 |
 
 ## Accumulated Context
 
@@ -58,6 +59,8 @@ Plan: Not started
 - [Phase 08]: EmbeddedSession constructor expanded from 2 to 7 parameters
 - [Phase 08]: Smoke tier tests only -- D-09 data-seeded tests deferred pending FUTURE-03 collection CRUD
 - [Phase 08]: EmbeddedConfigBuilder used for test YAML instead of hand-written strings
+- [Phase 09]: BackupExecutor made public for cross-module access from JNA/Panama backends
+- [Phase 09]: Persist path extracted from config YAML at embedded session creation time via SnakeYAML
 
 ### Pending Todos
 
@@ -69,6 +72,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-03-26T13:10:41Z
-Stopped at: Completed 08-02-PLAN.md
+Last session: 2026-03-27T05:38:53Z
+Stopped at: Completed 09-01-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v0.5.0
 milestone_name: Java API Surface
-status: "Phase 09 plan 01 complete"
-stopped_at: Completed 09-01-PLAN.md
-last_updated: "2026-03-27T05:38:53Z"
+status: Executing Phase 09
+stopped_at: Phase 9 context gathered
+last_updated: "2026-03-27T05:28:55.158Z"
 progress:
   total_phases: 5
   completed_phases: 3
-  total_plans: 8
-  completed_plans: 8
+  total_plans: 9
+  completed_plans: 7
 ---
 
 # Project State
@@ -23,8 +23,8 @@ See: .planning/PROJECT.md (updated 2026-03-21)
 
 ## Current Position
 
-Phase: 9
-Plan: 1 of 1 complete
+Phase: 09 (backup-api) — EXECUTING
+Plan: 1 of 2
 
 ## Performance Metrics
 
@@ -37,7 +37,6 @@ Plan: 1 of 1 complete
 | 07 | 02 | 2min | 1 | 2 |
 | 08 | 01 | 3min | 2 | 4 |
 | 08 | 02 | 9min | 2 | 2 |
-| 09 | 01 | 8min | 2 | 13 |
 
 ## Accumulated Context
 
@@ -59,8 +58,6 @@ Plan: 1 of 1 complete
 - [Phase 08]: EmbeddedSession constructor expanded from 2 to 7 parameters
 - [Phase 08]: Smoke tier tests only -- D-09 data-seeded tests deferred pending FUTURE-03 collection CRUD
 - [Phase 08]: EmbeddedConfigBuilder used for test YAML instead of hand-written strings
-- [Phase 09]: BackupExecutor made public for cross-module access from JNA/Panama backends
-- [Phase 09]: Persist path extracted from config YAML at embedded session creation time via SnakeYAML
 
 ### Pending Todos
 
@@ -72,6 +69,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-03-27T05:38:53Z
-Stopped at: Completed 09-01-PLAN.md
-Resume file: None
+Last session: 2026-03-27T05:04:36.371Z
+Stopped at: Phase 9 context gathered
+Resume file: .planning/phases/09-backup-api/09-CONTEXT.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v0.5.0
 milestone_name: Java API Surface
-status: Executing Phase 09
-stopped_at: Phase 9 context gathered
-last_updated: "2026-03-27T05:28:55.158Z"
+status: Ready to execute
+stopped_at: Completed 09-02-PLAN.md
+last_updated: "2026-03-27T05:52:51.230Z"
 progress:
   total_phases: 5
-  completed_phases: 3
+  completed_phases: 4
   total_plans: 9
-  completed_plans: 7
+  completed_plans: 9
 ---
 
 # Project State
@@ -24,7 +24,7 @@ See: .planning/PROJECT.md (updated 2026-03-21)
 ## Current Position
 
 Phase: 09 (backup-api) — EXECUTING
-Plan: 1 of 2
+Plan: 2 of 2
 
 ## Performance Metrics
 
@@ -37,6 +37,7 @@ Plan: 1 of 2
 | 07 | 02 | 2min | 1 | 2 |
 | 08 | 01 | 3min | 2 | 4 |
 | 08 | 02 | 9min | 2 | 2 |
+| Phase 09 P02 | 4min | 2 tasks | 4 files |
 
 ## Accumulated Context
 
@@ -69,6 +70,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-03-27T05:04:36.371Z
-Stopped at: Phase 9 context gathered
-Resume file: .planning/phases/09-backup-api/09-CONTEXT.md
+Last session: 2026-03-27T05:52:51.227Z
+Stopped at: Completed 09-02-PLAN.md
+Resume file: None

--- a/.planning/phases/09-backup-api/09-01-PLAN.md
+++ b/.planning/phases/09-backup-api/09-01-PLAN.md
@@ -1,0 +1,448 @@
+---
+phase: 09-backup-api
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java
+  - java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
+  - java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java
+  - java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java
+  - java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java
+  - java/core/src/test/java/tech/amikos/chroma/local/core/EmbeddedSessionTest.java
+  - java/core/src/test/java/tech/amikos/chroma/local/core/BackupExecutorTest.java
+  - java/core/src/test/java/tech/amikos/chroma/local/core/BackupResultTest.java
+  - java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java
+  - java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java
+autonomous: true
+requirements: [BKUP-01, BKUP-02, BKUP-03]
+
+must_haves:
+  truths:
+    - "BackupExecutor.execute() copies a source directory to destination, writes a manifest JSON, and returns a BackupManifest"
+    - "BackupResult wraps both a BackupManifest and a new session (or null when left closed/stopped)"
+    - "EmbeddedSession.backup(options) delegates to a Function callback slot and returns BackupResult<EmbeddedSession>"
+    - "ServerSession.backup(options) delegates to a Function callback slot and returns BackupResult<ServerSession>"
+    - "BackupExecutor rejects leaveStopped for embedded mode and leaveClosed for server mode"
+    - "Both JNA and Panama backends construct backup callback lambdas that call BackupExecutor with close/restart hooks"
+  artifacts:
+    - path: "java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java"
+      provides: "Generic result type wrapping manifest + session"
+      exports: ["BackupResult"]
+    - path: "java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java"
+      provides: "Core backup algorithm (validate, close, copy, manifest, restart)"
+      contains: "static <S> BackupResult<S> execute"
+    - path: "java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java"
+      provides: "All-args package-private constructor for BackupExecutor"
+      contains: "BackupManifest(String schemaVersion"
+  key_links:
+    - from: "EmbeddedSession"
+      to: "BackupResult<EmbeddedSession>"
+      via: "Function<BackupOptions, BackupResult<EmbeddedSession>> backupAction callback slot"
+      pattern: "backupAction\\.apply"
+    - from: "ServerSession"
+      to: "BackupResult<ServerSession>"
+      via: "Function<BackupOptions, BackupResult<ServerSession>> backupAction callback slot"
+      pattern: "backupAction\\.apply"
+    - from: "JnaChromaRuntime.doStartEmbedded"
+      to: "BackupExecutor.execute"
+      via: "backup lambda injected at session construction"
+      pattern: "BackupExecutor\\.execute"
+    - from: "PanamaChromaRuntime.doStartEmbedded"
+      to: "BackupExecutor.execute"
+      via: "backup lambda injected at session construction"
+      pattern: "BackupExecutor\\.execute"
+---
+
+<objective>
+Implement the complete backup API for both embedded and server modes: core types (BackupResult, BackupExecutor), session wiring (callback slots in EmbeddedSession and ServerSession), and backend lambda construction (JNA and Panama).
+
+Purpose: This is the full production implementation of BKUP-01, BKUP-02, BKUP-03. After this plan, both JNA and Panama backends can execute backups end-to-end.
+Output: BackupResult.java, BackupExecutor.java, modified BackupManifest.java, wired EmbeddedSession/ServerSession, updated JNA/Panama backends, unit tests for core types.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/09-backup-api/09-CONTEXT.md
+@.planning/phases/09-backup-api/09-RESEARCH.md
+@.planning/phases/08-embedded-maintenance/08-01-SUMMARY.md
+
+@java/core/src/main/java/tech/amikos/chroma/local/core/BackupOptions.java
+@java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java
+@java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java
+@java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java
+@java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java
+@java/core/src/main/java/tech/amikos/chroma/local/core/JsonUtil.java
+@java/core/src/main/java/tech/amikos/chroma/local/core/AbstractChromaRuntime.java
+@java/core/src/test/java/tech/amikos/chroma/local/core/EmbeddedSessionTest.java
+@java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java
+@java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java
+@internal/runtime/backup.go
+
+<interfaces>
+<!-- Key types and contracts the executor needs. Extracted from codebase. -->
+
+From BackupOptions.java:
+```java
+public final class BackupOptions {
+    public String destinationPath();
+    public boolean includeMetadata();
+    public boolean leaveStopped();
+    public boolean leaveClosed();
+    public String toJson();
+    // Builder(String destinationPath).includeMetadata(bool).leaveStopped(bool).leaveClosed(bool).build()
+}
+```
+
+From BackupManifest.java (current — no all-args constructor):
+```java
+public final class BackupManifest {
+    BackupManifest() { /* no-arg for Gson */ }
+    public String schemaVersion();
+    public String mode();
+    public String createdAt();
+    public String wrapperVersion();
+    public List<String> sourcePaths();
+    public String destinationPath();
+    public String snapshotPath();
+    public String manifestPath();
+    public boolean includeMetadata();
+    public int fileCount();
+    public long totalBytes();
+    public List<BackupFileMetadata> files();
+}
+```
+
+From BackupFileMetadata.java (current — no all-args constructor):
+```java
+public final class BackupFileMetadata {
+    BackupFileMetadata() { /* no-arg for Gson */ }
+    public String path();
+    public long sizeBytes();
+    public String mode();
+    public String sha256();
+    public String modifiedAt();
+}
+```
+
+From EmbeddedSession.java (current 7-param constructor):
+```java
+public EmbeddedSession(long handle, LongConsumer closeAction,
+    BiFunction<Long, String, RebuildCollectionResult> rebuildAction,
+    BiFunction<Long, String, CompactionResult> compactCollectionAction,
+    BiFunction<Long, String, CompactionResult> compactAllAction,
+    BiFunction<Long, String, WALPruneResult> pruneWalCollectionAction,
+    BiFunction<Long, String, WALPruneResult> pruneWalAllAction)
+```
+
+From ServerSession.java (current 6-param constructor):
+```java
+public ServerSession(long handle, LongConsumer stopAction, LongConsumer freeAction,
+    LongToIntFunction portAccessor, LongFunction<String> addressAccessor,
+    LongFunction<String> persistPathAccessor)
+```
+
+From JsonUtil.java:
+```java
+final class JsonUtil {
+    static final Gson GSON = new GsonBuilder()
+        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
+    static <T> T fromJson(String json, Class<T> type);
+    static String toJson(Object obj);
+}
+```
+
+From JnaChromaRuntime.java (embedded session construction pattern):
+```java
+return new EmbeddedSession(handle, this::embeddedFree,
+    (h, json) -> callFfiJson(() -> ..., RebuildCollectionResult.class),
+    (h, json) -> callFfiJson(() -> ..., CompactionResult.class),
+    ...);
+```
+
+From PanamaChromaRuntime.java (server session construction pattern):
+```java
+return new ServerSession(handle, this::serverStop, this::serverFree,
+    this::serverPort, this::serverAddress, this::serverPersistPath);
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create BackupResult and BackupExecutor core types with BackupManifest constructor</name>
+  <files>
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java,
+    java/core/src/test/java/tech/amikos/chroma/local/core/BackupResultTest.java,
+    java/core/src/test/java/tech/amikos/chroma/local/core/BackupExecutorTest.java
+  </files>
+  <read_first>
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupOptions.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/JsonUtil.java,
+    internal/runtime/backup.go
+  </read_first>
+  <action>
+**1. Create `BackupResult.java`** (per D-03, D-05):
+- Package: `tech.amikos.chroma.local.core`
+- Public final class, generic `BackupResult<S>`
+- Two fields: `private final BackupManifest manifest` and `private final S session`
+- Constructor: `public BackupResult(BackupManifest manifest, S session)` -- manifest is `Objects.requireNonNull`, session is nullable (null when leaveClosed/leaveStopped)
+- Two getters: `public BackupManifest manifest()` and `public S session()` (session may return null)
+- No AutoCloseable -- keep it simple per Claude's discretion
+
+**2. Add all-args package-private constructor to `BackupManifest.java`** (per Pitfall 2 in RESEARCH.md):
+- Add new constructor: `BackupManifest(String schemaVersion, String mode, String createdAt, String wrapperVersion, List<String> sourcePaths, String destinationPath, String snapshotPath, String manifestPath, boolean includeMetadata, int fileCount, long totalBytes, List<BackupFileMetadata> files)`
+- Package-private visibility (no modifier) so BackupExecutor in same package can use it
+- Keep the existing no-arg constructor for Gson deserialization
+- Store `sourcePaths` and `files` as `new ArrayList<>(...)` defensive copies (or null-safe)
+
+**3. Add all-args package-private constructor to `BackupFileMetadata.java`**:
+- Add new constructor: `BackupFileMetadata(String path, long sizeBytes, String mode, String sha256, String modifiedAt)`
+- Package-private visibility, keep existing no-arg constructor
+
+**4. Create `BackupExecutor.java`** (per D-01, D-02, D-08):
+- Package: `tech.amikos.chroma.local.core`, package-private (no `public`)
+- Single static method: `static <S> BackupResult<S> execute(String mode, String persistPath, BackupOptions options, Runnable closeAction, Supplier<S> restartAction)`
+- Algorithm (matches Go's `internal/runtime/backup.go`):
+  a. **Validate mode options** (per D-08): if mode is "embedded" and `options.leaveStopped()` is true, throw `IllegalArgumentException("leaveStopped is only valid for server backups")`. If mode is "server" and `options.leaveClosed()` is true, throw `IllegalArgumentException("leaveClosed is only valid for embedded backups")`.
+  b. **Resolve destination**: `Path dest = Path.of(options.destinationPath()).toAbsolutePath().normalize()`
+  c. **Path containment check**: verify dest/persist is NOT inside persistPath using `isWithinPath(dest, Path.of(persistPath).toAbsolutePath().normalize())`. Throw `IllegalArgumentException` if contained.
+  d. **Ensure empty dir**: if dest exists, verify it is a directory and is empty. If not exists, create via `Files.createDirectories`. If exists and non-empty, throw `IllegalArgumentException("destination path must be empty")`.
+  e. **Close**: call `closeAction.run()`
+  f. **Copy directory**: call `copyDirectory(Path.of(persistPath), dest.resolve("persist"), options.includeMetadata())` -- uses `Files.walkFileTree` with `SimpleFileVisitor`. Reject symbolic links. Compute SHA-256 per file via `MessageDigest`. Track fileCount, totalBytes, and optionally build `List<BackupFileMetadata>`.
+  g. **Write manifest**: create `BackupManifest` via the new all-args constructor. Write to `dest.resolve("backup_manifest.json")` using a Gson instance with `LOWER_CASE_WITH_UNDERSCORES` and `setPrettyPrinting()`. Append newline.
+  h. **Restart** (conditional): if mode is "embedded" and `!options.leaveClosed()`, or mode is "server" and `!options.leaveStopped()`, call `restartAction.get()` and wrap result. If left closed/stopped, return `new BackupResult<>(manifest, null)`.
+  i. Return `new BackupResult<>(manifest, newSession)`.
+
+- Helper methods (all private static):
+  - `copyDirectory(Path source, Path destination, boolean includeMetadata)` returning a `CopyResult` record with `int fileCount, long totalBytes, List<BackupFileMetadata> files`
+  - `copyFileWithHash(Path source, Path destination)` returning `String` (hex SHA-256). Uses `MessageDigest.getInstance("SHA-256")`, 8192-byte buffer, streaming read/write/digest. Preserves lastModifiedTime via `Files.setLastModifiedTime`.
+  - `hexEncode(byte[] bytes)` -- `StringBuilder` with `String.format("%02x", b)` or `HexFormat.of().formatHex(bytes)` (Java 17+)
+  - `isWithinPath(Path path, Path parent)` -- normalize both, check `path.startsWith(parent)`
+  - `writeManifest(Path manifestPath, BackupManifest manifest)` -- Gson pretty-print, write string + newline via `Files.writeString`
+
+- Constants: `MANIFEST_FILENAME = "backup_manifest.json"`, `SNAPSHOT_DIRNAME = "persist"`, `SCHEMA_VERSION = "v1"`
+
+- For `wrapperVersion`: call `"java"` (simple string; Go uses the Go binary version, Java has no equivalent FFI version call to make from within the backup utility)
+
+- For `createdAt`: use `java.time.Instant.now().toString()` (ISO-8601 format)
+
+- For `sourcePaths`: `List.of(Path.of(persistPath).toAbsolutePath().normalize().toString())`
+
+- For BackupFileMetadata `mode` field: use `String.format("0%o", Files.getPosixFilePermissions(file))` on POSIX systems, or `"0644"` fallback on Windows (wrap in try-catch for `UnsupportedOperationException`)
+
+- A private record `CopyResult(int fileCount, long totalBytes, List<BackupFileMetadata> files)` for copyDirectory return.
+
+- Handle the case where source persist path does not exist (empty database): create empty snapshot dir and set fileCount=0, totalBytes=0.
+
+**5. Create `BackupResultTest.java`**:
+- Test: constructor with non-null manifest and non-null session returns both via getters
+- Test: constructor with null manifest throws NullPointerException
+- Test: constructor with null session (left closed) returns null from session()
+
+**6. Create `BackupExecutorTest.java`**:
+- Pure filesystem unit tests (no FFI) using `@TempDir`:
+- Test: `execute()` with valid options copies a file tree and writes manifest JSON
+  - Create source dir with a sentinel file "sentinel.txt" containing "test-data"
+  - Call `BackupExecutor.execute("embedded", sourcePath, options, closeAction, restartAction)` where closeAction is a no-op Runnable and restartAction returns a mock session string
+  - Verify: dest/persist/sentinel.txt exists with same content, dest/backup_manifest.json exists and is parseable via `JsonUtil.fromJson(Files.readString(...), BackupManifest.class)`, manifest.fileCount() >= 1
+- Test: rejects leaveStopped for embedded mode
+- Test: rejects leaveClosed for server mode
+- Test: rejects destination inside source path
+- Test: rejects non-empty destination directory
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/local-go-chroma/java && gradle --no-daemon :core:test :core:check 2>&1 | tail -20</automated>
+  </verify>
+  <acceptance_criteria>
+    - BackupResult.java exists and contains `public final class BackupResult<S>`
+    - BackupResult.java contains `public BackupManifest manifest()` and `public S session()`
+    - BackupExecutor.java exists and contains `static <S> BackupResult<S> execute(`
+    - BackupExecutor.java contains `leaveStopped is only valid for server backups`
+    - BackupExecutor.java contains `leaveClosed is only valid for embedded backups`
+    - BackupExecutor.java contains `Files.walkFileTree`
+    - BackupExecutor.java contains `MessageDigest.getInstance("SHA-256")`
+    - BackupExecutor.java contains `backup_manifest.json`
+    - BackupManifest.java contains a second constructor with `String schemaVersion` parameter (all-args)
+    - BackupFileMetadata.java contains a second constructor with `String path` parameter (all-args)
+    - BackupResultTest.java exists and passes
+    - BackupExecutorTest.java exists and passes
+    - `gradle --no-daemon :core:test` exits 0
+    - `gradle --no-daemon :core:check` exits 0
+  </acceptance_criteria>
+  <done>BackupResult, BackupExecutor, and manifest constructors are implemented and unit-tested. Core backup algorithm copies directories, computes SHA-256, writes JSON manifest, validates mode-specific options, and handles leave-closed/leave-stopped. All core:test and core:check pass.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Wire backup callback slots into sessions and backends</name>
+  <files>
+    java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java,
+    java/core/src/test/java/tech/amikos/chroma/local/core/EmbeddedSessionTest.java,
+    java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java,
+    java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java
+  </files>
+  <read_first>
+    java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java,
+    java/core/src/test/java/tech/amikos/chroma/local/core/EmbeddedSessionTest.java,
+    java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java,
+    java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
+  </read_first>
+  <action>
+**1. Modify `EmbeddedSession.java`** (per D-06, D-07):
+- Add import: `java.util.function.Function`
+- Add field: `private final Function<BackupOptions, BackupResult<EmbeddedSession>> backupAction;`
+- Expand constructor from 7 to 8 parameters. The new 8th parameter is `Function<BackupOptions, BackupResult<EmbeddedSession>> backupAction`. Add null check: `if (backupAction == null) throw new IllegalArgumentException("backupAction must be set");`
+- Add method:
+```java
+public BackupResult<EmbeddedSession> backup(BackupOptions options) {
+    ensureOpen();
+    if (options == null) throw new IllegalArgumentException("options is required");
+    return backupAction.apply(options);
+}
+```
+
+**2. Modify `ServerSession.java`** (per D-06, D-07):
+- Add import: `java.util.function.Function`
+- Add field: `private final Function<BackupOptions, BackupResult<ServerSession>> backupAction;`
+- Expand constructor from 6 to 7 parameters. The new 7th parameter is `Function<BackupOptions, BackupResult<ServerSession>> backupAction`. Add null check.
+- Replace the existing `backup(BackupOptions)` stub that throws `UnsupportedOperationException` with:
+```java
+public BackupResult<ServerSession> backup(BackupOptions options) {
+    ensureOpen();
+    if (options == null) throw new IllegalArgumentException("options is required");
+    return backupAction.apply(options);
+}
+```
+
+**3. Update `EmbeddedSessionTest.java`**:
+- Add a stub constant: `private static final Function<BackupOptions, BackupResult<EmbeddedSession>> STUB_BACKUP = opts -> { throw new UnsupportedOperationException("stub"); };`
+- Update the `create()` helper to pass `STUB_BACKUP` as the 8th argument
+- Update all direct `new EmbeddedSession(...)` calls in test methods (constructorRejectsNull* tests and convenience overload delegation tests) to include the 8th `STUB_BACKUP` argument
+- Add a `constructorRejectsNullBackupAction` test
+- Add a `backupRejectsNullOptions` test
+- Add a `backupThrowsAfterClose` test
+
+**4. Modify `JnaChromaRuntime.java`**:
+- In `doStartEmbedded(String configYaml)`: after obtaining the handle, capture `configYaml` in a local `final String savedYaml = configYaml;`. Construct the backup lambda:
+```java
+Function<BackupOptions, BackupResult<EmbeddedSession>> backupAction = opts -> {
+    // Read persist path from embedded handle BEFORE close
+    String persistPath = callFfiBorrowedString(
+        () -> Pointer.nativeValue(bindings.chroma_server_persist_path(new Pointer(handle))));
+    // NOTE: Embedded doesn't have a persist path accessor via FFI.
+    // The persist path is extracted from the config YAML.
+    // Parse YAML to get persist path, or use a simpler approach.
+};
+```
+
+Actually, per Pitfall 4 in RESEARCH.md and the CONTEXT.md code_context: "The backend lambda captures the persist path from the config at session creation time." The embedded runtime has no FFI accessor for persist path. Parse the persist path from the configYaml at construction time:
+
+For JNA `doStartEmbedded`:
+```java
+// Extract persist_path from configYaml (YAML key: persist_path under chroma: key)
+// Use a simple approach: parse the YAML to find the persist path
+String persistPath = extractPersistPath(configYaml);
+Function<BackupOptions, BackupResult<EmbeddedSession>> backupAction = opts ->
+    BackupExecutor.execute(
+        "embedded",
+        persistPath,
+        opts,
+        () -> embeddedFree(handle),
+        () -> doStartEmbedded(savedYaml));
+```
+
+Add a private helper `extractPersistPath(String configYaml)` that parses the YAML config to extract the `persist_path` value. Use a simple regex or string search: find line matching `persist_path:` and extract the value. Since SnakeYAML is already a dependency, use `new org.yaml.snakeyaml.Yaml().load(configYaml)` to parse as `Map<String, Object>`, then navigate to get the persist path from the nested map structure (`chroma.persist_path` or top-level `persist_path` depending on YAML structure).
+
+Actually, to keep it simple and avoid SnakeYAML dependency in the backend modules, add a **package-private static utility method in core**: `BackupExecutor.extractPersistPath(String configYaml)` that uses SnakeYAML (already a core dependency) to parse and extract. The method navigates the YAML map: the embedded config has structure `chroma: { persist_path: "..." }` based on EmbeddedConfigBuilder output.
+
+For JNA `doStartServer`:
+```java
+String persistPath = serverPersistPath(handle);  // FFI accessor exists for server
+final String savedYaml = configYaml;
+Function<BackupOptions, BackupResult<ServerSession>> backupAction = opts ->
+    BackupExecutor.execute(
+        "server",
+        persistPath,
+        opts,
+        () -> { serverStop(handle); serverFree(handle); },
+        () -> doStartServer(savedYaml));
+```
+
+Pass the backup lambda as the new 8th/7th parameter to `EmbeddedSession`/`ServerSession` constructors.
+
+**5. Modify `PanamaChromaRuntime.java`**:
+- Same pattern as JNA. In `doStartEmbedded`: extract persist path from configYaml, construct backup lambda calling `BackupExecutor.execute("embedded", ...)` with `this::embeddedFree` as close and `() -> doStartEmbedded(savedYaml)` as restart.
+- In `doStartServer`: read persist path via `serverPersistPath(handle)`, construct backup lambda calling `BackupExecutor.execute("server", ...)` with `() -> { serverStop(handle); serverFree(handle); }` as close and `() -> doStartServer(savedYaml)` as restart.
+- Pass backup lambdas to the new session constructors.
+
+**Important:** The `BackupExecutor.extractPersistPath(String configYaml)` method should be added to `BackupExecutor.java`. It uses SnakeYAML to parse the config YAML, navigates the nested map structure looking for `persist_path` under the `chroma` key, and returns it as a String. This avoids duplicating YAML parsing in each backend. The method signature: `static String extractPersistPath(String configYaml)`.
+
+For the YAML structure, based on `EmbeddedConfigBuilder` output (from Phase 6), the config looks like:
+```yaml
+chroma:
+  persist_path: /some/path
+```
+So the extraction is: `((Map) yamlMap.get("chroma")).get("persist_path").toString()`.
+
+For server config, `persist_path` is also under the `chroma` key, but server has an FFI accessor so it doesn't need this extraction.
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/local-go-chroma/java && gradle --no-daemon :core:test :core:check :jna:check :panama:check 2>&1 | tail -20</automated>
+  </verify>
+  <acceptance_criteria>
+    - EmbeddedSession.java constructor has 8 parameters (the 8th is `Function<BackupOptions, BackupResult<EmbeddedSession>> backupAction`)
+    - EmbeddedSession.java contains `public BackupResult<EmbeddedSession> backup(BackupOptions options)`
+    - EmbeddedSession.java contains `backupAction.apply(options)`
+    - ServerSession.java constructor has 7 parameters (the 7th is `Function<BackupOptions, BackupResult<ServerSession>> backupAction`)
+    - ServerSession.java contains `public BackupResult<ServerSession> backup(BackupOptions options)`
+    - ServerSession.java does NOT contain `UnsupportedOperationException` for backup
+    - JnaChromaRuntime.java contains `BackupExecutor.execute` in doStartEmbedded
+    - JnaChromaRuntime.java contains `BackupExecutor.execute` in doStartServer
+    - PanamaChromaRuntime.java contains `BackupExecutor.execute` in doStartEmbedded
+    - PanamaChromaRuntime.java contains `BackupExecutor.execute` in doStartServer
+    - EmbeddedSessionTest.java contains `STUB_BACKUP` and `constructorRejectsNullBackupAction`
+    - `gradle --no-daemon :core:test` exits 0
+    - `gradle --no-daemon :core:check :jna:check :panama:check` exits 0
+  </acceptance_criteria>
+  <done>EmbeddedSession and ServerSession have backup callback slots. Both JNA and Panama backends construct backup lambdas that call BackupExecutor.execute() with appropriate close/restart hooks. All modules compile and lint-check passes.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. `cd java && gradle --no-daemon :core:test` -- all unit tests pass (BackupResultTest, BackupExecutorTest, EmbeddedSessionTest, ServerSessionTest)
+2. `cd java && gradle --no-daemon :core:check :jna:check :panama:check` -- all three modules compile and lint-check pass
+3. grep verification: `BackupExecutor.execute` appears in both JnaChromaRuntime.java and PanamaChromaRuntime.java
+4. grep verification: `backupAction.apply` appears in both EmbeddedSession.java and ServerSession.java
+</verification>
+
+<success_criteria>
+- BackupResult and BackupExecutor exist in core with full algorithm implementation
+- BackupManifest has all-args package-private constructor
+- EmbeddedSession has 8-param constructor with backup callback slot
+- ServerSession has 7-param constructor with backup callback slot (no more UnsupportedOperationException on backup)
+- Both JNA and Panama backends construct and inject backup lambdas
+- All unit tests pass, all modules compile
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/09-backup-api/09-01-SUMMARY.md`
+</output>

--- a/.planning/phases/09-backup-api/09-01-SUMMARY.md
+++ b/.planning/phases/09-backup-api/09-01-SUMMARY.md
@@ -1,0 +1,132 @@
+---
+phase: 09-backup-api
+plan: 01
+subsystem: api
+tags: [backup, filesystem, sha256, java, jna, panama, session-lifecycle]
+
+requires:
+  - phase: 06-core-foundation-types
+    provides: BackupOptions, BackupManifest, BackupFileMetadata, JsonUtil, AbstractChromaRuntime
+  - phase: 07-server-lifecycle
+    provides: ServerSession with callback slot pattern
+  - phase: 08-embedded-maintenance
+    provides: EmbeddedSession with 7-param constructor and callback slot pattern
+provides:
+  - BackupResult generic type wrapping manifest and new session
+  - BackupExecutor core algorithm (close-copy-manifest-restart)
+  - Backup callback slots in EmbeddedSession and ServerSession
+  - JNA and Panama backup lambda construction
+affects: [10-server-maintenance]
+
+tech-stack:
+  added: []
+  patterns: [backup-executor-utility, session-invalidation-via-new-result]
+
+key-files:
+  created:
+    - java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java
+    - java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
+    - java/core/src/test/java/tech/amikos/chroma/local/core/BackupResultTest.java
+    - java/core/src/test/java/tech/amikos/chroma/local/core/BackupExecutorTest.java
+  modified:
+    - java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java
+    - java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java
+    - java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java
+    - java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java
+    - java/core/src/test/java/tech/amikos/chroma/local/core/EmbeddedSessionTest.java
+    - java/core/src/test/java/tech/amikos/chroma/local/core/ServerSessionTest.java
+    - java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java
+    - java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java
+
+key-decisions:
+  - "BackupExecutor made public (not package-private) for cross-module access from JNA/Panama backends"
+  - "Persist path extracted from config YAML at embedded session creation time via SnakeYAML parsing"
+
+patterns-established:
+  - "BackupExecutor utility: centralized filesystem algorithm with close/restart callback injection"
+  - "BackupResult<S>: generic result type for operations that invalidate and recreate sessions"
+
+requirements-completed: [BKUP-01, BKUP-02, BKUP-03]
+
+duration: 8min
+completed: 2026-03-27
+---
+
+# Phase 9 Plan 1: Backup API Summary
+
+**BackupExecutor with SHA-256 directory copy, JSON manifest, and session callback wiring for both JNA and Panama backends**
+
+## Performance
+
+- **Duration:** 8 min
+- **Started:** 2026-03-27T05:30:53Z
+- **Completed:** 2026-03-27T05:38:53Z
+- **Tasks:** 2
+- **Files modified:** 13
+
+## Accomplishments
+- Core backup algorithm replicating Go's close-copy-manifest-restart pattern in pure Java
+- BackupResult generic type enabling session replacement after backup invalidates the old handle
+- Both JNA and Panama backends wired with backup lambdas for embedded and server modes
+- Mode validation (embedded rejects leaveStopped, server rejects leaveClosed) matching Go behavior
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create BackupResult and BackupExecutor core types** - `305153d` (feat)
+2. **Task 2: Wire backup callback slots into sessions and backends** - `e47551a` (feat)
+
+## Files Created/Modified
+- `java/core/.../BackupResult.java` - Generic result type wrapping BackupManifest + new session
+- `java/core/.../BackupExecutor.java` - Core backup algorithm: validate, close, copy with SHA-256, write manifest, restart
+- `java/core/.../BackupManifest.java` - Added all-args package-private constructor for BackupExecutor
+- `java/core/.../BackupFileMetadata.java` - Added all-args package-private constructor
+- `java/core/.../EmbeddedSession.java` - Expanded to 8-param constructor with backup callback slot
+- `java/core/.../ServerSession.java` - Expanded to 7-param constructor, backup stub replaced with real implementation
+- `java/jna/.../JnaChromaRuntime.java` - Backup lambda construction in doStartEmbedded and doStartServer
+- `java/panama/.../PanamaChromaRuntime.java` - Backup lambda construction in doStartEmbedded and doStartServer
+- `java/core/.../BackupResultTest.java` - Unit tests for BackupResult type
+- `java/core/.../BackupExecutorTest.java` - Unit tests for backup algorithm (copy, manifest, validation)
+- `java/core/.../EmbeddedSessionTest.java` - Updated for 8-param constructor, added backup null/close tests
+- `java/core/.../ServerSessionTest.java` - Updated for 7-param constructor, added backup null/close tests
+
+## Decisions Made
+- BackupExecutor made public instead of package-private -- the plan specified package-private, but JNA and Panama backends in separate packages need to call BackupExecutor.execute(). Made class and key methods public.
+- Persist path for embedded sessions extracted from config YAML using SnakeYAML at session creation time, supporting both top-level `persist_path` and nested `chroma.persist_path` keys.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Made BackupExecutor public for cross-module access**
+- **Found during:** Task 2 (session wiring)
+- **Issue:** Plan specified BackupExecutor as package-private, but JNA/Panama modules cannot access package-private classes from a different package
+- **Fix:** Made BackupExecutor class and execute/extractPersistPath methods public
+- **Files modified:** java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
+- **Verification:** :jna:check and :panama:check compile successfully
+- **Committed in:** e47551a (Task 2 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking)
+**Impact on plan:** Necessary for cross-module compilation. No scope creep.
+
+## Issues Encountered
+None
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Backup API fully wired for both embedded and server modes
+- Integration tests (BKUP-04) with real FFI are deferred to a future plan or the verifier
+- Phase 10 (Server Maintenance) can proceed -- ServerSession backup is now functional
+
+## Self-Check: PASSED
+
+All created files verified on disk. All commit hashes (305153d, e47551a) found in git log.
+
+---
+*Phase: 09-backup-api*
+*Completed: 2026-03-27*

--- a/.planning/phases/09-backup-api/09-02-PLAN.md
+++ b/.planning/phases/09-backup-api/09-02-PLAN.md
@@ -1,0 +1,304 @@
+---
+phase: 09-backup-api
+plan: 02
+type: execute
+wave: 2
+depends_on: [09-01]
+files_modified:
+  - java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaEmbeddedBackupTest.java
+  - java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaServerBackupTest.java
+  - java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaEmbeddedBackupTest.java
+  - java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaServerBackupTest.java
+autonomous: true
+requirements: [BKUP-04]
+
+must_haves:
+  truths:
+    - "Embedded backup via JNA creates a backup directory with persist/ subdirectory containing copied files and a parseable backup_manifest.json"
+    - "Embedded backup via Panama creates identical output to JNA"
+    - "Server backup via JNA creates a backup directory with valid manifest and the server is accessible afterward"
+    - "Server backup via Panama creates identical output to JNA"
+    - "Edge case tests reject invalid destinations and cross-mode option misuse in both backends"
+  artifacts:
+    - path: "java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaEmbeddedBackupTest.java"
+      provides: "JNA embedded backup integration tests"
+      min_lines: 40
+    - path: "java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaServerBackupTest.java"
+      provides: "JNA server backup integration tests"
+      min_lines: 40
+    - path: "java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaEmbeddedBackupTest.java"
+      provides: "Panama embedded backup integration tests"
+      min_lines: 40
+    - path: "java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaServerBackupTest.java"
+      provides: "Panama server backup integration tests"
+      min_lines: 40
+  key_links:
+    - from: "JnaEmbeddedBackupTest"
+      to: "EmbeddedSession.backup()"
+      via: "runtime.startEmbedded(yaml) then session.backup(options)"
+      pattern: "session\\.backup"
+    - from: "JnaServerBackupTest"
+      to: "ServerSession.backup()"
+      via: "runtime.startServer(yaml) then session.backup(options)"
+      pattern: "session\\.backup"
+---
+
+<objective>
+Create integration tests for backup in both JNA and Panama backends, covering embedded and server modes, sentinel file verification, manifest parsing, and edge cases.
+
+Purpose: Verify BKUP-04 -- that backup creates valid output directories with expected contents in both backends. Tests use real FFI sessions with sentinel files pre-seeded in @TempDir.
+Output: 4 test files (JNA embedded/server, Panama embedded/server) with identical test structure per D-12.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/09-backup-api/09-CONTEXT.md
+@.planning/phases/09-backup-api/09-RESEARCH.md
+@.planning/phases/09-backup-api/09-01-SUMMARY.md
+
+@java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaEmbeddedMaintenanceTest.java
+@java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java
+@java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
+@java/core/src/main/java/tech/amikos/chroma/local/core/BackupOptions.java
+@java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java
+@java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java
+@java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java
+
+<interfaces>
+<!-- Key types the test executor needs. -->
+
+From BackupResult.java (created in Plan 01):
+```java
+public final class BackupResult<S> {
+    public BackupManifest manifest();
+    public S session();  // null if left closed/stopped
+}
+```
+
+From BackupOptions.java:
+```java
+new BackupOptions.Builder(destinationPath).includeMetadata(true).leaveClosed(true).leaveStopped(true).build()
+```
+
+From BackupManifest.java:
+```java
+public String schemaVersion();  // "v1"
+public String mode();           // "embedded" or "server"
+public int fileCount();
+public long totalBytes();
+public String destinationPath();
+public String snapshotPath();
+public String manifestPath();
+public boolean includeMetadata();
+public List<BackupFileMetadata> files();
+```
+
+From EmbeddedSession.java (updated in Plan 01):
+```java
+public BackupResult<EmbeddedSession> backup(BackupOptions options);
+```
+
+From ServerSession.java (updated in Plan 01):
+```java
+public BackupResult<ServerSession> backup(BackupOptions options);
+```
+
+Test pattern from JnaEmbeddedMaintenanceTest.java:
+```java
+String libPath = System.getenv("CHROMA_LIB_PATH");
+Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+String yaml = new EmbeddedConfigBuilder().persistPath(persistDir.toAbsolutePath().toString()).allowReset(true).build();
+try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath); EmbeddedSession session = runtime.startEmbedded(yaml)) { ... }
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create embedded backup integration tests for JNA and Panama</name>
+  <files>
+    java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaEmbeddedBackupTest.java,
+    java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaEmbeddedBackupTest.java
+  </files>
+  <read_first>
+    java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaEmbeddedMaintenanceTest.java,
+    java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaEmbeddedMaintenanceTest.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupOptions.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java
+  </read_first>
+  <action>
+Create `JnaEmbeddedBackupTest.java` with the following tests (per D-10, D-11, D-12). All tests follow the established pattern: `Assumptions.assumeTrue` on CHROMA_LIB_PATH, `EmbeddedConfigBuilder` for YAML, `@TempDir` for paths.
+
+**Test 1: `embeddedBackupCreatesDirectoryWithManifest`**
+- Create `@TempDir Path persistDir` and `@TempDir Path backupDir` (two separate temp dirs). NOTE: Since backup requires an empty destination and @TempDir creates the dir, use a subdirectory: `Path dest = backupDir.resolve("output");`
+- Pre-seed a sentinel file: `Files.writeString(persistDir.resolve("sentinel.txt"), "backup-test-data")`
+- Start embedded session with EmbeddedConfigBuilder using persistDir
+- Call `BackupResult<EmbeddedSession> result = session.backup(new BackupOptions.Builder(dest.toString()).includeMetadata(true).build())`
+- The old session is now invalidated. Use `result.session()` as the new session (close it in finally/try-with-resources).
+- Assertions:
+  - `assertNotNull(result.manifest())`
+  - `assertEquals("v1", result.manifest().schemaVersion())`
+  - `assertEquals("embedded", result.manifest().mode())`
+  - `assertTrue(result.manifest().fileCount() >= 1)` -- at least the sentinel file
+  - `assertTrue(Files.exists(dest.resolve("persist").resolve("sentinel.txt")))` -- sentinel copied
+  - `assertEquals("backup-test-data", Files.readString(dest.resolve("persist").resolve("sentinel.txt")))` -- content matches
+  - `assertTrue(Files.exists(dest.resolve("backup_manifest.json")))` -- manifest exists
+  - `assertNotNull(result.session())` -- new session returned (not left closed)
+  - Close `result.session()` after assertions
+
+**Test 2: `embeddedBackupWithLeaveClosed`**
+- Same setup as Test 1 but with `new BackupOptions.Builder(dest.toString()).leaveClosed(true).build()`
+- After backup: `assertNull(result.session())` -- no restart
+- Verify manifest still exists and is parseable
+
+**Test 3: `embeddedBackupRejectsLeaveStopped`** (per D-08)
+- Start embedded session, attempt `session.backup(new BackupOptions.Builder(dest.toString()).leaveStopped(true).build())`
+- `assertThrows(IllegalArgumentException.class, ...)` with message containing "leaveStopped"
+- Close the original session (it should still be usable since the backup should fail before closing)
+
+**Test 4: `embeddedBackupRejectsNullOptions`**
+- `assertThrows(IllegalArgumentException.class, () -> session.backup(null))`
+
+**Test 5: `embeddedBackupThrowsAfterClose`**
+- Close session, then `assertThrows(IllegalStateException.class, () -> session.backup(...))`
+
+Create `PanamaEmbeddedBackupTest.java` with **identical test structure** (per D-12), only changing:
+- Package: `tech.amikos.chroma.local.panama`
+- Runtime: `PanamaChromaRuntime.init(libPath)` instead of `JnaChromaRuntime.init(libPath)`
+- Class name: `PanamaEmbeddedBackupTest`
+
+**Important test patterns:**
+- Use `@TempDir(cleanup = CleanupMode.NEVER)` for the persistDir (Windows compatibility per Pitfall 5)
+- The backupDir can use default cleanup since it's just output
+- Import `org.junit.jupiter.api.io.CleanupMode` for this
+- After `session.backup()`, the original session variable is closed/invalidated. You must use `result.session()` for subsequent operations. Structure the test so that the new session is properly closed even if assertions fail.
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/local-go-chroma && make build && cd java && CHROMA_LIB_PATH=$(cd .. && pwd)/shim/target/debug/libchroma_shim.dylib gradle --no-daemon :jna:test --tests '*JnaEmbeddedBackupTest*' :panama:test --tests '*PanamaEmbeddedBackupTest*' 2>&1 | tail -30</automated>
+  </verify>
+  <acceptance_criteria>
+    - JnaEmbeddedBackupTest.java exists with at least 5 test methods
+    - PanamaEmbeddedBackupTest.java exists with at least 5 test methods
+    - Both files contain `session.backup(` calls
+    - Both files contain `result.manifest().schemaVersion()` assertion
+    - Both files contain `sentinel.txt` sentinel file pattern
+    - Both files contain `leaveStopped` rejection test
+    - Both files contain `CleanupMode.NEVER` on persist dir
+    - `gradle --no-daemon :jna:test --tests '*JnaEmbeddedBackupTest*'` exits 0
+    - `gradle --no-daemon :panama:test --tests '*PanamaEmbeddedBackupTest*'` exits 0
+  </acceptance_criteria>
+  <done>Embedded backup integration tests pass in both JNA and Panama backends, verifying sentinel file copy, manifest generation, leaveClosed behavior, and mode-specific option rejection.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create server backup integration tests for JNA and Panama</name>
+  <files>
+    java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaServerBackupTest.java,
+    java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaServerBackupTest.java
+  </files>
+  <read_first>
+    java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaEmbeddedBackupTest.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java,
+    java/core/src/main/java/tech/amikos/chroma/local/core/BackupOptions.java
+  </read_first>
+  <action>
+Create `JnaServerBackupTest.java` with the following tests (per D-10, D-11, D-12). Tests follow the server lifecycle test pattern: `ServerConfigBuilder` for YAML, `findFreePort()` utility, `@TempDir` for paths.
+
+**Helper:** Add a `findFreePort()` method (same pattern as JnaServerLifecycleTest from Phase 7):
+```java
+private static int findFreePort() throws IOException {
+    try (var socket = new java.net.ServerSocket(0)) {
+        return socket.getLocalPort();
+    }
+}
+```
+
+**Test 1: `serverBackupCreatesDirectoryWithManifest`**
+- Create `@TempDir(cleanup = CleanupMode.NEVER) Path persistDir` and `@TempDir Path backupDir`
+- Pre-seed sentinel: `Files.writeString(persistDir.resolve("sentinel.txt"), "server-backup-test")`
+- Start server with `ServerConfigBuilder` using persistDir and a free port
+- `Path dest = backupDir.resolve("output");`
+- Call `BackupResult<ServerSession> result = session.backup(new BackupOptions.Builder(dest.toString()).includeMetadata(true).build())`
+- The old session is invalidated; use `result.session()` for the new server
+- Assertions:
+  - `assertNotNull(result.manifest())`
+  - `assertEquals("v1", result.manifest().schemaVersion())`
+  - `assertEquals("server", result.manifest().mode())`
+  - `assertTrue(result.manifest().fileCount() >= 1)`
+  - `assertTrue(Files.exists(dest.resolve("persist").resolve("sentinel.txt")))`
+  - `assertTrue(Files.exists(dest.resolve("backup_manifest.json")))`
+  - `assertNotNull(result.session())` -- server restarted
+  - Verify server is accessible: `assertTrue(result.session().port() > 0)`
+  - Close `result.session()`
+
+**Test 2: `serverBackupWithLeaveStopped`**
+- Same setup but with `.leaveStopped(true)`
+- `assertNull(result.session())` -- server not restarted
+- Manifest still valid
+
+**Test 3: `serverBackupRejectsLeaveClosed`** (per D-08)
+- `assertThrows(IllegalArgumentException.class, () -> session.backup(new BackupOptions.Builder(dest.toString()).leaveClosed(true).build()))`
+- Message should contain "leaveClosed"
+
+**Test 4: `serverBackupRejectsNullOptions`**
+- `assertThrows(IllegalArgumentException.class, () -> session.backup(null))`
+
+**Test 5: `serverBackupThrowsAfterClose`**
+- Close session, then `assertThrows(IllegalStateException.class, () -> session.backup(...))`
+
+Create `PanamaServerBackupTest.java` with **identical test structure** (per D-12), only changing:
+- Package: `tech.amikos.chroma.local.panama`
+- Runtime: `PanamaChromaRuntime.init(libPath)`
+- Class name: `PanamaServerBackupTest`
+
+**Important patterns:**
+- Use `@TempDir(cleanup = CleanupMode.NEVER)` for persistDir (Windows compatibility)
+- Server backup does stop-backup-restart: the old session handle is freed, a new server starts. The `result.session()` is a fresh ServerSession with a potentially different port if using ephemeral ports. Use `ServerConfigBuilder` with an explicit port to keep it predictable, or verify with `result.session().port() > 0`.
+- For server tests, use `try (JnaChromaRuntime runtime = ...) { ... }` with manual session lifecycle management since backup invalidates the session.
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/experiments/amikos/local-go-chroma && make build && cd java && CHROMA_LIB_PATH=$(cd .. && pwd)/shim/target/debug/libchroma_shim.dylib gradle --no-daemon :jna:test --tests '*JnaServerBackupTest*' :panama:test --tests '*PanamaServerBackupTest*' 2>&1 | tail -30</automated>
+  </verify>
+  <acceptance_criteria>
+    - JnaServerBackupTest.java exists with at least 5 test methods
+    - PanamaServerBackupTest.java exists with at least 5 test methods
+    - Both files contain `session.backup(` calls
+    - Both files contain `assertEquals("server", result.manifest().mode())`
+    - Both files contain `sentinel.txt` sentinel file pattern
+    - Both files contain `leaveClosed` rejection test
+    - Both files contain `findFreePort()` helper
+    - `gradle --no-daemon :jna:test --tests '*JnaServerBackupTest*'` exits 0
+    - `gradle --no-daemon :panama:test --tests '*PanamaServerBackupTest*'` exits 0
+  </acceptance_criteria>
+  <done>Server backup integration tests pass in both JNA and Panama backends, verifying sentinel file copy, manifest generation, server restart after backup, leaveStopped behavior, and mode-specific option rejection.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. `make test-java` -- full Java test suite passes (all existing tests + new backup tests)
+2. All 4 test files exist and contain the expected test methods
+3. Both embedded and server backup tests verify sentinel file presence, manifest parsing, and mode-specific option rejection
+</verification>
+
+<success_criteria>
+- 4 new integration test files created with identical structure across JNA and Panama
+- Embedded backup tests verify: sentinel copy, manifest correctness, leaveClosed, leaveStopped rejection, null options, closed session
+- Server backup tests verify: sentinel copy, manifest correctness, server restart, leaveStopped, leaveClosed rejection, null options, closed session
+- `make test-java` passes with all new and existing tests
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/09-backup-api/09-02-SUMMARY.md`
+</output>

--- a/.planning/phases/09-backup-api/09-02-SUMMARY.md
+++ b/.planning/phases/09-backup-api/09-02-SUMMARY.md
@@ -1,0 +1,98 @@
+---
+phase: 09-backup-api
+plan: 02
+subsystem: testing
+tags: [backup, integration-tests, java, jna, panama, sentinel-file, manifest]
+
+requires:
+  - phase: 09-backup-api
+    plan: 01
+    provides: BackupResult, BackupExecutor, BackupOptions, backup callback slots in sessions
+provides:
+  - JNA embedded backup integration tests (5 test methods)
+  - JNA server backup integration tests (5 test methods)
+  - Panama embedded backup integration tests (5 test methods)
+  - Panama server backup integration tests (5 test methods)
+affects: []
+
+tech-stack:
+  added: []
+  patterns: [sentinel-file-verification, backup-manifest-parsing, mode-specific-option-rejection]
+
+key-files:
+  created:
+    - java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaEmbeddedBackupTest.java
+    - java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaServerBackupTest.java
+    - java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaEmbeddedBackupTest.java
+    - java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaServerBackupTest.java
+  modified: []
+
+key-decisions:
+  - "No decisions required -- tests follow established patterns from Phase 8 maintenance tests"
+
+patterns-established:
+  - "Backup test pattern: sentinel file seeded in persistDir, backup to subdirectory of backupDir, verify sentinel in dest/persist/, parse manifest"
+  - "Mode rejection tests: embedded rejects leaveStopped, server rejects leaveClosed"
+
+requirements-completed: [BKUP-04]
+
+duration: 4min
+completed: 2026-03-27
+---
+
+# Phase 9 Plan 2: Backup Integration Tests Summary
+
+**20 integration tests across JNA and Panama verifying backup sentinel copy, manifest parsing, session lifecycle, and mode-specific option rejection**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-03-27T05:47:07Z
+- **Completed:** 2026-03-27T05:51:48Z
+- **Tasks:** 2
+- **Files modified:** 4
+
+## Accomplishments
+- Embedded backup tests verify sentinel file copy, manifest schema/mode, leaveClosed behavior, and leaveStopped rejection
+- Server backup tests verify sentinel file copy, manifest schema/mode, server restart after backup, leaveStopped behavior, and leaveClosed rejection
+- All 20 tests pass across both JNA and Panama backends with identical structure per D-12
+- Edge case coverage: null options, closed session guards, mode-specific option misuse
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create embedded backup integration tests for JNA and Panama** - `eeafe8d` (test)
+2. **Task 2: Create server backup integration tests for JNA and Panama** - `9f99392` (test)
+
+## Files Created/Modified
+- `java/jna/.../JnaEmbeddedBackupTest.java` - 5 embedded backup tests via JNA backend
+- `java/jna/.../JnaServerBackupTest.java` - 5 server backup tests via JNA backend with findFreePort
+- `java/panama/.../PanamaEmbeddedBackupTest.java` - 5 embedded backup tests via Panama backend
+- `java/panama/.../PanamaServerBackupTest.java` - 5 server backup tests via Panama backend with findFreePort
+
+## Decisions Made
+None - followed plan as specified.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+None
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Backup API fully tested end-to-end in both backends
+- Phase 10 (Server Maintenance) can proceed with confidence that backup infrastructure works correctly
+- All BKUP requirements (01-04) now complete
+
+## Self-Check: PASSED
+
+All created files verified on disk. All commit hashes (eeafe8d, 9f99392) found in git log.
+
+---
+*Phase: 09-backup-api*
+*Completed: 2026-03-27*

--- a/.planning/phases/09-backup-api/09-CONTEXT.md
+++ b/.planning/phases/09-backup-api/09-CONTEXT.md
@@ -1,0 +1,121 @@
+# Phase 9: Backup API - Context
+
+**Gathered:** 2026-03-27
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Implement backup with filesystem copy, manifest generation, and option builder for both embedded and server modes in Java (JNA + Panama). Backup is purely wrapper-side logic — no FFI calls exist in the Rust shim for backup. The Go implementation closes the runtime, copies the persistence directory, writes a JSON manifest, and restarts. Java must replicate this pattern using the existing `BackupOptions` and `BackupManifest` types from Phase 6.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Backup logic location
+- **D-01:** Hybrid approach — core module owns 100% of the filesystem algorithm (directory copy, SHA256 hashing, manifest JSON writing). Backends inject close + restart callbacks via the existing slot pattern. No logic duplication across JNA and Panama.
+- **D-02:** A utility class in core (e.g., `BackupExecutor`) implements the close → copy → write-manifest → restart algorithm. Backends construct it with their lifecycle hooks.
+
+### Session restart after backup
+- **D-03:** `backup()` returns a `BackupResult<S>` containing both the `BackupManifest` and a new session instance. The old session is invalidated (closed). Caller uses the new session going forward.
+- **D-04:** Sessions remain immutable — `final long handle` is preserved. No mutable handle refactoring.
+
+### BackupResult type design
+- **D-05:** Generic `BackupResult<S>` — one class with `manifest()` and `session()` getters. Returns `BackupResult<EmbeddedSession>` from embedded backup, `BackupResult<ServerSession>` from server backup.
+
+### Restart callback shape
+- **D-06:** Session's `backup()` uses a `Function<BackupOptions, BackupResult<S>>` callback slot injected at construction time. The backend's lambda internally calls core's backup utility with the right restarter (a `Supplier<S>` that creates a fresh session from saved config). The Supplier is internal to the lambda — not exposed in the public API.
+- **D-07:** User calls `session.backup(options)` cleanly — no internal plumbing exposed. The callback slot bundles the full close-copy-restart algorithm.
+
+### BackupOptions mode validation
+- **D-08:** Validation happens at `backup()` call time inside the core backup algorithm, not at `BackupOptions.build()` time. Embedded rejects `leaveStopped`, server rejects `leaveClosed`. Matches Go's `resolveBackupOptions` pattern.
+- **D-09:** `BackupOptions` class stays unchanged from Phase 6 — no new builder subclasses or mode parameters.
+
+### Test strategy
+- **D-10:** Filesystem verify + edge cases (B+D tier). Pre-seed a sentinel file in `@TempDir` before starting the session, call `backup()`, verify the sentinel appears in the backup output directory and manifest JSON is parseable with correct `fileCount`.
+- **D-11:** Edge case tests: invalid destination (null/empty), non-empty destination directory, cross-mode option rejection (leaveStopped on embedded, leaveClosed on server).
+- **D-12:** Identical test structure in both `:jna:test` and `:panama:test` modules — consistent with Phase 7 D-07 and Phase 8 D-10.
+
+### Claude's Discretion
+- Exact utility class naming and internal structure for the backup algorithm
+- Whether `BackupResult` implements `AutoCloseable` (delegating to the contained session)
+- Sentinel file content and naming in tests
+- Order of implementation (core utility first vs session wiring first)
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Go backup implementation (reference)
+- `internal/runtime/backup.go` — Full backup algorithm: `resolveBackupOptions`, `executeBackup`, `copyDirectory`, `copyFile`, `writeManifest`, `ensureEmptyDir`. Mode validation at option resolution. Server/Embedded `Backup()` methods with close-copy-restart pattern.
+
+### Java core types (Phase 6 output — ready to use)
+- `java/core/src/main/java/tech/amikos/chroma/local/core/BackupOptions.java` — Builder with destination, includeMetadata, leaveStopped, leaveClosed. Unchanged.
+- `java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java` — Result POJO with all fields matching Go's BackupManifest.
+- `java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java` — Per-file metadata POJO (path, sizeBytes, mode, sha256, modifiedAt).
+
+### Session types (wiring targets)
+- `java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java` — Must add `backup()` method + callback slot. Currently has 7 constructor params (handle, close, 5 maintenance callbacks).
+- `java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java` — Has `backup(BackupOptions)` stub throwing UnsupportedOperationException. Must wire real implementation + add callback slot.
+
+### Backend implementations
+- `java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java` — JNA backend; must construct backup callback lambda and inject into sessions.
+- `java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java` — Panama backend; same changes as JNA.
+
+### FFI reference (no backup symbols — confirms wrapper-side)
+- `shim/src/lib.rs` — No `chroma_backup`, `chroma_embedded_backup`, or `chroma_server_backup` symbols. Backup is 100% wrapper-side.
+
+### Requirements
+- `.planning/REQUIREMENTS.md` — BKUP-01 through BKUP-04
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `BackupOptions` + `BackupManifest` + `BackupFileMetadata`: All defined in core from Phase 6, ready to use
+- `JsonUtil.toJson()` / `JsonUtil.fromJson()`: For manifest serialization/deserialization
+- `EmbeddedSession` callback slot pattern: `BiFunction<Long, String, T>` for maintenance ops — backup uses `Function<BackupOptions, BackupResult<S>>` instead (different signature since no FFI)
+- `AbstractChromaRuntime.callFfiVoid/callFfiJson`: NOT used for backup (no FFI calls), but backends use these to implement close/restart
+
+### Established Patterns
+- Constructor callback injection: all session methods delegate to backend-injected lambdas
+- `AtomicBoolean` close guard with `compareAndSet` for idempotent close
+- `@TempDir` with `CleanupMode.NEVER` for Windows compatibility in tests
+- `EmbeddedConfigBuilder` / `ServerConfigBuilder` for test YAML generation
+
+### Integration Points
+- `EmbeddedSession` constructor must expand by 1 parameter (backup callback)
+- `ServerSession` constructor must expand by 1 parameter (backup callback)
+- Both backend `doStartEmbedded()` and `doStartServer()` methods must construct and inject backup callbacks
+- `Makefile` `test-java` target runs both `:jna:test` and `:panama:test`
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Go's backup algorithm copies the persistence directory with `filepath.WalkDir` and computes SHA256 per file — Java equivalent uses `Files.walkFileTree` with `MessageDigest`
+- Go validates destination is not inside source persist path (containment check) — replicate in Java
+- Go writes manifest as indented JSON via `json.MarshalIndent` — Java uses `JsonUtil` (Gson) with pretty printing
+- The sentinel-file test pattern mirrors Go's existing backup tests — pre-write a file into the persist temp dir before starting the session, then verify it appears in the backup snapshot after `backup()` completes
+- `BackupResult<S>` should be a simple final class in core with two fields: `BackupManifest manifest` and `S session`
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope
+
+</deferred>
+
+---
+
+*Phase: 09-backup-api*
+*Context gathered: 2026-03-27*

--- a/.planning/phases/09-backup-api/09-DISCUSSION-LOG.md
+++ b/.planning/phases/09-backup-api/09-DISCUSSION-LOG.md
@@ -1,0 +1,110 @@
+# Phase 9: Backup API - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-03-27
+**Phase:** 09-backup-api
+**Areas discussed:** Backup logic location, Session restart after backup, BackupOptions mode validation, Test strategy, BackupResult type design, Restart callback shape, Public backup API
+
+---
+
+## Backup Logic Location
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Core module utility | Core owns full implementation as utility class. Sessions call directly. Core gains filesystem I/O. | |
+| Backend callback slots | Same BiFunction pattern as maintenance ops. Both backends implement identical filesystem logic. | |
+| Hybrid | Core owns filesystem copy/manifest logic. Backends inject close + restart callbacks. Zero duplication. | ✓ |
+
+**User's choice:** Hybrid
+**Notes:** Since backup has zero FFI calls (unlike Phase 8 maintenance ops), putting identical filesystem logic in both backends creates false symmetry. Core owns the algorithm, backends supply lifecycle hooks.
+
+---
+
+## Session Restart After Backup
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Return new session | backup() returns BackupResult(manifest, newSession). Old session invalidated. Sessions stay immutable. | ✓ |
+| Callback with resetHandle | Backend restart callback returns new handle. Core calls package-private resetHandle(). | |
+| Close-only backup | backup() always leaves session closed. No restart logic. Caller manages restart. | |
+| Mutable handle | Change handle from final to AtomicLong. Same object survives like Go. | |
+
+**User's choice:** Return new session
+**Notes:** Preserves the immutable session pattern from Phases 6-8. Caller swaps their session reference.
+
+---
+
+## BackupOptions Mode Validation
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| At backup() call time | Core backup algorithm validates mode-specific flags. BackupOptions unchanged from Phase 6. | ✓ |
+| Two builder subclasses | EmbeddedBackupOptions and ServerBackupOptions. Compile-time safety. | |
+| Builder with mode parameter | BackupOptions.Builder(dest, mode) validates at build(). | |
+
+**User's choice:** At backup() call time
+**Notes:** Matches Go's resolveBackupOptions pattern. Mode is only known at call time anyway, so this is the earliest possible validation point.
+
+---
+
+## Test Strategy
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| A: Smoke only | Start session, backup, assert manifest non-null. | |
+| B: Smoke + filesystem verify | Sentinel file in temp dir, verify backup copies it, parse manifest JSON. | |
+| B+D: Filesystem + edge cases | Sentinel file verify + manifest parse + error cases (bad dest, wrong mode flags). | ✓ |
+
+**User's choice:** B+D: filesystem + edge cases
+**Notes:** Full coverage without needing collection CRUD API. Sentinel file pattern mirrors Go's existing backup tests.
+
+---
+
+## BackupResult Type Design
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Generic BackupResult\<S\> | One class with manifest() + session() getters. Type-safe. | ✓ |
+| Two concrete types | EmbeddedBackupResult and ServerBackupResult. No generics, duplicated structure. | |
+| Untyped session | BackupResult with Object session(). Caller casts. | |
+
+**User's choice:** Generic BackupResult\<S\>
+**Notes:** None
+
+---
+
+## Restart Callback Shape
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Supplier\<S\> at backup call | backup(options, restarter) — backend passes lambda creating fresh session. | |
+| Constructor callback slot | Add restart callback to session constructor. Permanent slot. | |
+
+**User's choice:** Initially selected Supplier at call time, then refined to callback slot approach for public API cleanliness.
+
+---
+
+## Public Backup API
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Callback slot | Session gets Function\<BackupOptions, BackupResult\<S\>\> injected at construction. User calls session.backup(options). | ✓ |
+| Session calls core directly | Session.backup() calls BackupUtil.execute() with injected restarter. | |
+
+**User's choice:** Callback slot
+**Notes:** Backend constructs a lambda that internally uses core's backup utility with the right restarter (a Supplier that creates a fresh session). The Supplier is internal to the lambda, not exposed in the public API.
+
+---
+
+## Claude's Discretion
+
+- Exact utility class naming and internal structure for backup algorithm
+- Whether BackupResult implements AutoCloseable
+- Sentinel file content and naming in tests
+- Order of implementation
+
+## Deferred Ideas
+
+None — discussion stayed within phase scope

--- a/.planning/phases/09-backup-api/09-RESEARCH.md
+++ b/.planning/phases/09-backup-api/09-RESEARCH.md
@@ -1,0 +1,437 @@
+# Phase 9: Backup API - Research
+
+**Researched:** 2026-03-27
+**Domain:** Java backup API — filesystem copy, manifest generation, session lifecycle
+**Confidence:** HIGH
+
+## Summary
+
+Phase 9 implements backup functionality for both embedded and server sessions in Java. Unlike maintenance operations (Phase 8), backup involves zero FFI calls — the entire algorithm runs in wrapper-side Java code. The core backup algorithm (close runtime, copy persistence directory, write JSON manifest, restart runtime) is already proven in the Go implementation (`internal/runtime/backup.go`) and the Java implementation must replicate this pattern.
+
+The key architectural challenge is that backup invalidates the session handle (it closes and restarts the runtime), so the session object itself cannot be reused. The CONTEXT.md decision D-03 resolves this by returning a `BackupResult<S>` containing both the manifest and a new session instance. The old session is invalidated. This differs from Go where the same `Server`/`Embedded` struct mutates its internal handle.
+
+All three Phase 6 data types (`BackupOptions`, `BackupManifest`, `BackupFileMetadata`) already exist in `core` and are ready to use. The primary implementation work is: (1) a `BackupExecutor` utility in core that owns the filesystem algorithm, (2) a `BackupResult<S>` result type in core, (3) wiring backup callback slots into `EmbeddedSession` and `ServerSession`, and (4) backend lambdas in JNA and Panama that construct the backup callback.
+
+**Primary recommendation:** Implement a `BackupExecutor` class in core that receives close/restart callbacks and owns the copy-manifest-restart algorithm. Backends inject their lifecycle hooks via the existing callback slot pattern. Tests use sentinel files pre-seeded in `@TempDir` to verify backup correctness.
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+- **D-01:** Hybrid approach — core module owns 100% of the filesystem algorithm (directory copy, SHA256 hashing, manifest JSON writing). Backends inject close + restart callbacks via the existing slot pattern. No logic duplication across JNA and Panama.
+- **D-02:** A utility class in core (e.g., `BackupExecutor`) implements the close -> copy -> write-manifest -> restart algorithm. Backends construct it with their lifecycle hooks.
+- **D-03:** `backup()` returns a `BackupResult<S>` containing both the `BackupManifest` and a new session instance. The old session is invalidated (closed). Caller uses the new session going forward.
+- **D-04:** Sessions remain immutable — `final long handle` is preserved. No mutable handle refactoring.
+- **D-05:** Generic `BackupResult<S>` — one class with `manifest()` and `session()` getters. Returns `BackupResult<EmbeddedSession>` from embedded backup, `BackupResult<ServerSession>` from server backup.
+- **D-06:** Session's `backup()` uses a `Function<BackupOptions, BackupResult<S>>` callback slot injected at construction time. The backend's lambda internally calls core's backup utility with the right restarter (a `Supplier<S>` that creates a fresh session from saved config). The Supplier is internal to the lambda — not exposed in the public API.
+- **D-07:** User calls `session.backup(options)` cleanly — no internal plumbing exposed. The callback slot bundles the full close-copy-restart algorithm.
+- **D-08:** Validation happens at `backup()` call time inside the core backup algorithm, not at `BackupOptions.build()` time. Embedded rejects `leaveStopped`, server rejects `leaveClosed`. Matches Go's `resolveBackupOptions` pattern.
+- **D-09:** `BackupOptions` class stays unchanged from Phase 6 — no new builder subclasses or mode parameters.
+- **D-10:** Filesystem verify + edge cases (B+D tier). Pre-seed a sentinel file in `@TempDir` before starting the session, call `backup()`, verify the sentinel appears in the backup output directory and manifest JSON is parseable with correct `fileCount`.
+- **D-11:** Edge case tests: invalid destination (null/empty), non-empty destination directory, cross-mode option rejection (leaveStopped on embedded, leaveClosed on server).
+- **D-12:** Identical test structure in both `:jna:test` and `:panama:test` modules — consistent with Phase 7 D-07 and Phase 8 D-10.
+
+### Claude's Discretion
+- Exact utility class naming and internal structure for the backup algorithm
+- Whether `BackupResult` implements `AutoCloseable` (delegating to the contained session)
+- Sentinel file content and naming in tests
+- Order of implementation (core utility first vs session wiring first)
+
+### Deferred Ideas (OUT OF SCOPE)
+None — discussion stayed within phase scope
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| BKUP-01 | `EmbeddedSession.backup(options)` performs directory copy with manifest and returns BackupManifest | Core BackupExecutor with Files.walkFileTree + SHA256 hashing; BackupResult wraps manifest + new session; EmbeddedSession gets backup callback slot |
+| BKUP-02 | `ServerSession.backup(options)` performs stop-backup-restart cycle and returns BackupManifest | Same BackupExecutor; ServerSession gets backup callback slot; backend lambda handles stop+free -> copy -> restart cycle |
+| BKUP-03 | `BackupOptions` builder supports destination, includeMetadata, leaveClosed/leaveStopped | Already implemented in Phase 6. D-08: mode validation at backup() call time, not build time. D-09: no changes to BackupOptions. |
+| BKUP-04 | Integration tests verify backup creates valid output directory in both backends | Sentinel file pattern from Go tests; edge case tests for invalid inputs; identical test structure in JNA and Panama modules |
+</phase_requirements>
+
+## Standard Stack
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| Java SE (java.nio.file) | 17+ | Files.walkFileTree, Path operations, file copying | JDK built-in, cross-platform directory traversal |
+| Java SE (java.security) | 17+ | MessageDigest for SHA-256 hashing | JDK built-in, no external dependency needed |
+| Gson | 2.13.2 | JSON manifest serialization (via existing JsonUtil) | Already in project as core dependency |
+| JUnit 5 | 5.11.4 | Test framework with @TempDir support | Already in project |
+
+### Supporting
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| SnakeYAML | 2.6 | Config builder YAML output (existing) | Test setup only — building config YAML for embedded/server startup |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| Files.walkFileTree | Apache Commons IO FileUtils.copyDirectory | Extra dependency for no benefit — JDK walkFileTree is sufficient and matches Go's filepath.WalkDir |
+| MessageDigest (SHA-256) | Guava Hashing | Extra dependency — JDK MessageDigest is identical in functionality |
+
+**Installation:** No new dependencies. All required libraries are already in `java/core/build.gradle.kts`.
+
+## Architecture Patterns
+
+### Recommended Project Structure (new files)
+```
+java/core/src/main/java/tech/amikos/chroma/local/core/
+  BackupExecutor.java       # Core backup algorithm (close -> copy -> manifest -> restart)
+  BackupResult.java         # Generic result type wrapping manifest + new session
+
+java/core/src/test/java/tech/amikos/chroma/local/core/
+  BackupExecutorTest.java   # Unit tests for backup algorithm (pure filesystem)
+  BackupResultTest.java     # Unit tests for result type
+
+java/jna/src/test/java/tech/amikos/chroma/local/jna/
+  JnaEmbeddedBackupTest.java  # Integration: embedded backup via JNA
+  JnaServerBackupTest.java    # Integration: server backup via JNA
+
+java/panama/src/test/java/tech/amikos/chroma/local/panama/
+  PanamaEmbeddedBackupTest.java  # Integration: embedded backup via Panama
+  PanamaServerBackupTest.java    # Integration: server backup via Panama
+```
+
+### Pattern 1: BackupExecutor Utility (D-01, D-02)
+**What:** A package-private utility class in core that owns the entire backup algorithm. It receives lifecycle callbacks (close + restart) from the calling backend. This centralizes all filesystem logic in one place.
+**When to use:** Always — the only entry point for backup operations.
+**Example:**
+```java
+// BackupExecutor — core module, package-private
+final class BackupExecutor {
+
+    static <S> BackupResult<S> execute(
+            String mode,           // "embedded" or "server"
+            String persistPath,    // source persist directory
+            BackupOptions options,
+            Runnable closeAction,
+            Supplier<S> restartAction) {
+
+        // 1. Validate options (mode-specific rejection)
+        // 2. Resolve and validate destination path
+        // 3. Ensure destination is empty
+        // 4. closeAction.run()  -- close the runtime
+        // 5. Copy persistence directory with optional SHA256
+        // 6. Write manifest JSON
+        // 7. If !leaveClosed/!leaveStopped: S newSession = restartAction.get()
+        // 8. Return BackupResult<S>(manifest, newSession)
+    }
+}
+```
+
+### Pattern 2: BackupResult Generic Type (D-03, D-05)
+**What:** A simple final generic class that wraps both the `BackupManifest` and the new session after restart.
+**When to use:** Return type from `session.backup(options)`.
+**Example:**
+```java
+public final class BackupResult<S> {
+    private final BackupManifest manifest;
+    private final S session;  // null if leaveClosed/leaveStopped
+
+    public BackupResult(BackupManifest manifest, S session) {
+        this.manifest = Objects.requireNonNull(manifest);
+        this.session = session;  // may be null
+    }
+
+    public BackupManifest manifest() { return manifest; }
+    public S session() { return session; }  // null means left closed/stopped
+}
+```
+
+### Pattern 3: Callback Slot for Backup (D-06, D-07)
+**What:** Sessions receive a `Function<BackupOptions, BackupResult<S>>` callback at construction time, matching the existing callback injection pattern used for maintenance operations.
+**When to use:** Session wiring in both EmbeddedSession and ServerSession.
+**Example for EmbeddedSession:**
+```java
+// EmbeddedSession constructor adds one more parameter:
+private final Function<BackupOptions, BackupResult<EmbeddedSession>> backupAction;
+
+public BackupResult<EmbeddedSession> backup(BackupOptions options) {
+    ensureOpen();
+    if (options == null) throw new IllegalArgumentException("options is required");
+    return backupAction.apply(options);
+}
+```
+
+### Pattern 4: Backend Lambda Construction (D-06)
+**What:** Each backend (`doStartEmbedded`, `doStartServer`) constructs the backup callback lambda that internally:
+  1. Captures the config YAML used to start the session
+  2. Calls `BackupExecutor.execute(mode, persistPath, options, closeRunnable, restartSupplier)`
+  3. The `closeRunnable` closes the current FFI handle
+  4. The `restartSupplier` starts a new session from saved config
+
+**Example for JNA embedded:**
+```java
+// In JnaChromaRuntime.doStartEmbedded():
+String savedYaml = configYaml;  // capture for restart
+Function<BackupOptions, BackupResult<EmbeddedSession>> backupAction = opts -> {
+    String persistPath = /* read from handle before close */;
+    return BackupExecutor.execute(
+        "embedded",
+        persistPath,
+        opts,
+        () -> embeddedFree(handle),          // close action
+        () -> doStartEmbedded(savedYaml));   // restart action
+};
+```
+
+### Anti-Patterns to Avoid
+- **Duplicating filesystem logic in backends:** The entire copy/hash/manifest algorithm belongs in core's `BackupExecutor`. Backends only provide close + restart lambdas.
+- **Mutating session handles:** D-04 locks `final long handle`. Backup creates a new session instead of mutating the existing one.
+- **Validating mode options in BackupOptions.build():** D-08 explicitly places mode validation in the backup algorithm, not at build time. This matches Go's `resolveBackupOptions` pattern.
+- **Using BackupOptions.toJson() for backup execution:** The `toJson()` method exists for serialization symmetry, not for driving the backup algorithm. BackupExecutor reads fields directly.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Directory tree copy | Manual byte-copy loops | `Files.walkFileTree` with `FileVisitor` | Handles nested dirs, permission preservation, symlink detection |
+| SHA-256 file hashing | Custom hash function | `MessageDigest.getInstance("SHA-256")` with streaming | JDK standard, handles large files via streaming |
+| JSON manifest writing | String concatenation | `JsonUtil.toJson()` with Gson pretty-printing | Already configured with `LOWER_CASE_WITH_UNDERSCORES` naming policy |
+| Path containment check | String prefix matching | `Path.relativize()` + check for `..` prefix | Handles edge cases (symlinks, trailing slashes, normalized paths) |
+| Empty directory validation | Manual stat + readdir | `Files.list(path).findFirst()` | Concise, auto-closeable stream |
+
+**Key insight:** Go's backup implementation (`internal/runtime/backup.go`) solves every edge case that matters: path containment validation, symlink rejection, empty-dir enforcement, source-path-not-exists handling. The Java implementation should replicate these checks faithfully using JDK equivalents, not invent new validation logic.
+
+## Common Pitfalls
+
+### Pitfall 1: Gson Field Naming for Manifest Serialization
+**What goes wrong:** Gson with `LOWER_CASE_WITH_UNDERSCORES` policy converts camelCase Java fields to snake_case JSON keys. The `BackupManifest` class uses Java field names (e.g., `schemaVersion`) which Gson maps to `schema_version`. If the `BackupExecutor` creates a manifest with misnamed fields, deserialization in tests will fail silently (fields stay null/zero).
+**Why it happens:** BackupManifest was designed for Gson deserialization from FFI JSON. For backup, we're constructing it in Java and serializing to disk.
+**How to avoid:** Use the existing `BackupManifest` class with its package-private constructor. Either add a builder/factory method, or construct a JSON object manually and write it. Verify in tests that `JsonUtil.fromJson(readFile, BackupManifest.class)` round-trips correctly.
+**Warning signs:** `fileCount` is 0 when it should be non-zero; fields are null after deserialization.
+
+### Pitfall 2: BackupManifest Construction
+**What goes wrong:** `BackupManifest` currently has only a package-private no-arg constructor (for Gson deserialization). There is no public constructor or builder for creating a manifest from scratch.
+**Why it happens:** Phase 6 designed BackupManifest for deserialization, not construction.
+**How to avoid:** Add a package-private constructor with all fields, or add a static factory method in `BackupManifest`. Since `BackupExecutor` lives in the same package (`core`), it can access package-private constructors. Alternatively, construct the manifest as a `Map<String, Object>` and serialize with Gson.
+**Warning signs:** Compile errors when trying to construct BackupManifest in BackupExecutor.
+
+### Pitfall 3: Session Handle Becomes Invalid After Backup Close
+**What goes wrong:** After `BackupExecutor` calls the close action, the old session's `handle` field is still non-zero but the native handle is freed. If anything tries to use the old session, it will segfault or corrupt memory.
+**Why it happens:** D-04 says handles are `final` — they cannot be zeroed out.
+**How to avoid:** The backup callback must mark the old session as closed via its `AtomicBoolean` closed flag before calling `BackupExecutor.execute()`. The callback lambda has access to the session's internal state because it's constructed in the backend. Alternatively, the close action passed to BackupExecutor should flip the session's closed flag.
+**Warning signs:** `IllegalStateException("session is closed")` after backup, or segfaults if the guard is missing.
+
+### Pitfall 4: Persist Path Retrieval Timing
+**What goes wrong:** The persist path must be read from the session before close. After close, accessors throw `IllegalStateException`.
+**Why it happens:** `EmbeddedSession` does not currently expose `persistPath()` (only `ServerSession` does). The persist path is needed by BackupExecutor to know what to copy.
+**How to avoid:** The backend lambda captures the persist path before passing it to BackupExecutor. For embedded, the persist path is known from the config YAML. For server, `session.persistPath()` is called before close. The backend lambda constructs everything upfront.
+**Warning signs:** `IllegalStateException` when trying to read persist path after close.
+
+### Pitfall 5: Windows @TempDir Cleanup Failures
+**What goes wrong:** JUnit's `@TempDir` cleanup fails on Windows when the Chroma native library holds file locks on the persist directory.
+**Why it happens:** The Rust runtime may keep SQLite database files locked.
+**How to avoid:** Use `@TempDir(cleanup = CleanupMode.NEVER)` for integration tests that interact with real FFI. This is the established pattern from Phase 7 (see `JnaServerLifecycleTest`).
+**Warning signs:** Flaky test failures on Windows CI with "unable to delete" errors.
+
+### Pitfall 6: Destination Inside Source Path
+**What goes wrong:** If the backup destination is a subdirectory of the source persist path, `copyDirectory` would recurse infinitely.
+**Why it happens:** User passes a path like `persistDir/backups/2024-01-01` as destination.
+**How to avoid:** Replicate Go's `isWithinPath` containment check. Use `Path.relativize()` and verify the relative path starts with `..` (meaning it's outside). Check this before creating the destination directory.
+**Warning signs:** Infinite loop or disk full error during backup.
+
+## Code Examples
+
+### Directory Copy with SHA-256 Hashing (from Go reference)
+```java
+// Java equivalent of Go's copyDirectory + copyFile pattern
+// Source: internal/runtime/backup.go lines 515-580
+static CopyResult copyDirectory(Path source, Path destination, boolean includeMetadata)
+        throws IOException {
+    Files.createDirectories(destination);
+    List<BackupFileMetadata> files = new ArrayList<>();
+    AtomicInteger fileCount = new AtomicInteger();
+    AtomicLong totalBytes = new AtomicLong();
+
+    Files.walkFileTree(source, new SimpleFileVisitor<>() {
+        @Override
+        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                throws IOException {
+            Path target = destination.resolve(source.relativize(dir));
+            Files.createDirectories(target);
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                throws IOException {
+            if (Files.isSymbolicLink(file)) {
+                throw new IOException("backup does not support symbolic links: " + file);
+            }
+            Path target = destination.resolve(source.relativize(file));
+            String sha256 = copyFileWithHash(file, target);
+            fileCount.incrementAndGet();
+            totalBytes.addAndGet(attrs.size());
+            if (includeMetadata) {
+                // Build BackupFileMetadata for each file
+            }
+            return FileVisitResult.CONTINUE;
+        }
+    });
+    return new CopyResult(fileCount.get(), totalBytes.get(), files);
+}
+```
+
+### SHA-256 Streaming Hash (from Go reference)
+```java
+// Java equivalent of Go's io.Copy(io.MultiWriter(destinationFile, hash), sourceFile)
+// Source: internal/runtime/backup.go lines 582-622
+static String copyFileWithHash(Path source, Path destination) throws IOException {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    try (InputStream in = Files.newInputStream(source);
+         OutputStream out = Files.newOutputStream(destination,
+                 StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = in.read(buffer)) != -1) {
+            out.write(buffer, 0, read);
+            digest.update(buffer, 0, read);
+        }
+    }
+    // Preserve file permissions and modification time
+    Files.setLastModifiedTime(destination,
+            Files.getLastModifiedTime(source));
+    return hexEncode(digest.digest());
+}
+```
+
+### Manifest JSON Writing
+```java
+// Java equivalent of Go's writeManifest (json.MarshalIndent)
+// Source: internal/runtime/backup.go lines 482-492
+// Use Gson with pretty printing for manifest output
+static void writeManifest(Path manifestPath, Map<String, Object> manifest)
+        throws IOException {
+    Gson gson = new GsonBuilder()
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+            .setPrettyPrinting()
+            .create();
+    String json = gson.toJson(manifest) + "\n";
+    Files.writeString(manifestPath, json, StandardOpenOption.CREATE_NEW);
+}
+```
+
+### Path Containment Check
+```java
+// Java equivalent of Go's isWithinPath
+// Source: internal/runtime/backup.go lines 687-697
+static boolean isWithinPath(Path path, Path parent) {
+    Path normalized = path.toAbsolutePath().normalize();
+    Path normalizedParent = parent.toAbsolutePath().normalize();
+    return normalized.startsWith(normalizedParent);
+}
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| BackupOptions validated at build() time | Validation at backup() call time (D-08) | Phase 9 decision | Mode-specific flags checked in algorithm, not builder |
+| Session.backup() returns BackupManifest | Session.backup() returns BackupResult<S> (D-03) | Phase 9 decision | Caller gets new session handle after backup |
+| ServerSession.backup() stub throws UnsupportedOperationException | Real backup implementation | Phase 9 | Full backup support |
+
+**Deprecated/outdated:**
+- `ServerSession.backup(BackupOptions)` returning `BackupManifest` (the current stub) will change to return `BackupResult<ServerSession>`
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | JUnit 5.11.4 |
+| Config file | `java/build.gradle.kts` (root test task config) |
+| Quick run command | `cd java && gradle --no-daemon :jna:test :panama:test` |
+| Full suite command | `make test-java` |
+
+### Phase Requirements to Test Map
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| BKUP-01 | EmbeddedSession.backup() creates backup dir with manifest | integration | `cd java && gradle --no-daemon :jna:test --tests '*JnaEmbeddedBackupTest*' -x :panama:test` | Wave 0 |
+| BKUP-02 | ServerSession.backup() stop-backup-restart cycle | integration | `cd java && gradle --no-daemon :jna:test --tests '*JnaServerBackupTest*' -x :panama:test` | Wave 0 |
+| BKUP-03 | BackupOptions builder fields + mode validation | unit | `cd java && gradle --no-daemon :core:test --tests '*BackupOptionsTest*'` | Exists (Phase 6 tests) + Wave 0 for mode validation |
+| BKUP-04 | Both JNA and Panama backends produce valid backup output | integration | `make test-java` | Wave 0 |
+
+### Sampling Rate
+- **Per task commit:** `cd java && gradle --no-daemon :core:test :jna:test :panama:test`
+- **Per wave merge:** `make test-java`
+- **Phase gate:** `make test-all` green before `/gsd:verify-work`
+
+### Wave 0 Gaps
+- [ ] `java/core/src/test/java/.../BackupExecutorTest.java` -- covers BKUP-01 algorithm unit tests
+- [ ] `java/core/src/test/java/.../BackupResultTest.java` -- covers BackupResult type
+- [ ] `java/jna/src/test/java/.../JnaEmbeddedBackupTest.java` -- covers BKUP-01, BKUP-04
+- [ ] `java/jna/src/test/java/.../JnaServerBackupTest.java` -- covers BKUP-02, BKUP-04
+- [ ] `java/panama/src/test/java/.../PanamaEmbeddedBackupTest.java` -- covers BKUP-01, BKUP-04
+- [ ] `java/panama/src/test/java/.../PanamaServerBackupTest.java` -- covers BKUP-02, BKUP-04
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|------------|-----------|---------|----------|
+| Java | All compilation/tests | Yes | 26 | -- |
+| Gradle | Build system | Yes | 9.4.1 | -- |
+| Make | Test runner | Yes | 3.81 | -- |
+| Rust shim (libchroma_shim) | FFI integration tests | Yes (built via `make build`) | -- | -- |
+
+**Missing dependencies with no fallback:** None.
+
+**Missing dependencies with fallback:** None.
+
+## Open Questions
+
+1. **BackupManifest construction mechanism**
+   - What we know: BackupManifest has only a package-private no-arg constructor (for Gson). BackupExecutor needs to construct one from computed values.
+   - What's unclear: Whether to add a package-private all-args constructor, or build the manifest as a Map and serialize/deserialize.
+   - Recommendation: Add a package-private all-args constructor to BackupManifest. Since BackupExecutor is in the same package, it can use it directly. This avoids the overhead and fragility of Map-based construction.
+
+2. **EmbeddedSession persist path access**
+   - What we know: ServerSession has `persistPath()` accessor. EmbeddedSession does not expose persist path.
+   - What's unclear: Whether to add a `persistPath()` accessor to EmbeddedSession or let the backend lambda extract it from the config YAML.
+   - Recommendation: The backend lambda should capture the persist path from the config at session creation time (it's known from the YAML). No need to add a new accessor. This keeps EmbeddedSession's public API unchanged.
+
+3. **BackupResult and leaveClosed/leaveStopped**
+   - What we know: When `leaveClosed=true` (embedded) or `leaveStopped=true` (server), backup does not restart. The returned BackupResult needs to communicate that no new session exists.
+   - What's unclear: Whether `session()` returns null, or whether BackupResult should have an `isSessionAvailable()` predicate.
+   - Recommendation: `session()` returns null when left closed/stopped. Javadoc documents this clearly. Simple and matches the nullable pattern.
+
+## Sources
+
+### Primary (HIGH confidence)
+- `internal/runtime/backup.go` -- Go reference implementation, full algorithm source
+- `internal/runtime/backup_test.go` -- Go test patterns (sentinel file, edge cases)
+- `java/core/src/main/java/tech/amikos/chroma/local/core/BackupOptions.java` -- Existing Phase 6 type
+- `java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java` -- Existing Phase 6 type
+- `java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java` -- Existing Phase 6 type
+- `java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java` -- Current session (7 constructor params)
+- `java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java` -- Current session with backup stub
+- `java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java` -- JNA backend
+- `java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java` -- Panama backend
+
+### Secondary (MEDIUM confidence)
+- Phase 8 test patterns (JnaEmbeddedMaintenanceTest, PanamaEmbeddedMaintenanceTest) -- established integration test structure
+
+## Project Constraints (from CLAUDE.md)
+
+- **Conventional commits** required for all commits
+- **Radical simplicity** -- keep architecture and implementation simple
+- **No verbose comments** -- code and function/variable names should be self-explanatory
+- **No scope creep** -- do exactly what is asked, nothing more
+- **Build commands:** `make test-java` for Java tests, `make test-all` for full suite
+- **Linting:** `gradle --no-daemon :core:check :jna:check :panama:check`
+- **No cgo** -- pure Go FFI via purego (not relevant to Java changes but project-wide principle)
+- **Facade pattern** -- root Go package re-exports; Java equivalent is the core module providing shared types
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH -- all dependencies already in project, no new libraries needed
+- Architecture: HIGH -- Go reference implementation is complete and well-tested, decisions locked in CONTEXT.md
+- Pitfalls: HIGH -- identified from direct code analysis of existing session patterns and Go edge cases
+
+**Research date:** 2026-03-27
+**Valid until:** 2026-04-27 (stable domain, no external dependency changes expected)

--- a/.planning/phases/09-backup-api/09-UAT.md
+++ b/.planning/phases/09-backup-api/09-UAT.md
@@ -1,0 +1,60 @@
+---
+status: complete
+phase: 09-backup-api
+source: 09-01-SUMMARY.md, 09-02-SUMMARY.md
+started: 2026-03-27T08:00:00Z
+updated: 2026-03-27T08:05:00Z
+---
+
+## Current Test
+
+[testing complete]
+
+## Tests
+
+### 1. Java Modules Compile
+expected: `make build-java` completes without errors. All three modules (core, jna, panama) compile successfully.
+result: pass
+
+### 2. Core Backup Unit Tests Pass
+expected: Running `:core:test` shows BackupResultTest and BackupExecutorTest passing. Tests cover backup result wrapping, manifest generation, SHA-256 file hashing, directory copy, and mode validation.
+result: pass
+notes: BackupExecutorTest (9 tests), BackupManifestTest (5 tests), BackupOptionsTest (5 tests), BackupResultTest (3 tests) -- all 22 core backup tests pass with 0 failures.
+
+### 3. JNA Embedded Backup Integration Tests Pass
+expected: Running `:jna:test` shows JnaEmbeddedBackupTest passing all 5 tests -- sentinel file copy to backup dir, manifest with correct schema/mode, leaveClosed behavior, null options default, and leaveStopped rejection for embedded mode.
+result: pass
+notes: 5 tests, 0 skipped, 0 failures, 0 errors.
+
+### 4. JNA Server Backup Integration Tests Pass
+expected: Running `:jna:test` shows JnaServerBackupTest passing all 5 tests -- sentinel file copy, manifest schema/mode, server restart after backup, leaveStopped behavior, and leaveClosed rejection for server mode.
+result: pass
+notes: 5 tests, 0 skipped, 0 failures, 0 errors.
+
+### 5. Panama Embedded Backup Integration Tests Pass
+expected: Running `:panama:test` shows PanamaEmbeddedBackupTest passing all 5 tests -- identical coverage to JNA embedded backup tests.
+result: pass
+notes: 5 tests, 0 skipped, 0 failures, 0 errors.
+
+### 6. Panama Server Backup Integration Tests Pass
+expected: Running `:panama:test` shows PanamaServerBackupTest passing all 5 tests -- identical coverage to JNA server backup tests.
+result: pass
+notes: 5 tests, 0 skipped, 0 failures, 0 errors.
+
+### 7. Go Tests Regression Check
+expected: `make test` passes. No regressions introduced by the Java backup API work.
+result: pass
+notes: All Go tests pass (16.940s). 2 tests skipped (WAL prune candidates not available in test runtime state -- expected).
+
+## Summary
+
+total: 7
+passed: 7
+issues: 0
+pending: 0
+skipped: 0
+blocked: 0
+
+## Gaps
+
+[none]

--- a/.planning/phases/09-backup-api/09-VALIDATION.md
+++ b/.planning/phases/09-backup-api/09-VALIDATION.md
@@ -1,0 +1,74 @@
+---
+phase: 9
+slug: backup-api
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-03-27
+---
+
+# Phase 9 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | JUnit 5 (JNA + Panama modules) |
+| **Config file** | `java/jna/build.gradle.kts`, `java/panama/build.gradle.kts` |
+| **Quick run command** | `make test-java` |
+| **Full suite command** | `make test-all` |
+| **Estimated runtime** | ~30 seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `make test-java`
+- **After every plan wave:** Run `make test-all`
+- **Before `/gsd:verify-work`:** Full suite must be green
+- **Max feedback latency:** 30 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|-----------|-------------------|-------------|--------|
+| 09-01-01 | 01 | 1 | BKUP-01 | unit | `make test-java` | ❌ W0 | ⬜ pending |
+| 09-01-02 | 01 | 1 | BKUP-02 | unit | `make test-java` | ❌ W0 | ⬜ pending |
+| 09-01-03 | 01 | 1 | BKUP-03 | unit | `make test-java` | ❌ W0 | ⬜ pending |
+| 09-01-04 | 01 | 1 | BKUP-04 | integration | `make test-java` | ❌ W0 | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] Backup test stubs in JNA and Panama test modules
+- [ ] Test fixtures for temp directory seeding with sentinel files
+
+*Existing test infrastructure (JUnit 5, @TempDir, EmbeddedConfigBuilder, ServerConfigBuilder) covers framework needs.*
+
+---
+
+## Manual-Only Verifications
+
+*All phase behaviors have automated verification.*
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 30s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/09-backup-api/09-VERIFICATION.md
+++ b/.planning/phases/09-backup-api/09-VERIFICATION.md
@@ -1,0 +1,142 @@
+---
+phase: 09-backup-api
+verified: 2026-03-27T08:00:00Z
+status: passed
+score: 6/6 must-haves verified
+re_verification: false
+---
+
+# Phase 9: Backup API Verification Report
+
+**Phase Goal:** Users can back up Chroma data from both embedded and server modes, producing a directory with a manifest file that records backup metadata
+**Verified:** 2026-03-27
+**Status:** passed
+**Re-verification:** No — initial verification
+
+---
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | `EmbeddedSession.backup(options)` creates a backup directory and returns a `BackupManifest` | VERIFIED | `EmbeddedSession.java` line 123–127: `backup()` delegates to `backupAction.apply(options)`. `BackupExecutor.execute("embedded", ...)` performs copy + manifest write and returns `BackupResult<EmbeddedSession>`. Integration tests (`JnaEmbeddedBackupTest`, `PanamaEmbeddedBackupTest`) assert `schemaVersion="v1"`, `mode="embedded"`, sentinel file copied. |
+| 2 | `ServerSession.backup(options)` performs stop-backup-restart cycle and returns a `BackupManifest` without corrupting server state | VERIFIED | `ServerSession.java` line 124–128: `backup()` delegates to `backupAction.apply(options)`. JNA/Panama backends inject lambda: `BackupExecutor.execute("server", persistPath, opts, () -> { serverStop(handle); serverFree(handle); }, () -> doStartServer(savedYaml))`. `JnaServerBackupTest.serverBackupCreatesDirectoryWithManifest` asserts `mode="server"`, new `result.session().port() > 0` (server restarted). |
+| 3 | `BackupOptions` builder supports `destination`, `includeMetadata`, `leaveClosed`/`leaveStopped` with validation at build time | VERIFIED | `BackupOptions.java`: Builder with all four fields, `build()` throws `IllegalArgumentException` when `destinationPath` is null/blank. Mode-specific option rejection is in `BackupExecutor.validateModeOptions()` (throws on leaveStopped for embedded, leaveClosed for server). |
+| 4 | Integration tests verify backup creates valid output directory with expected contents in both JNA and Panama backends | VERIFIED | 4 integration test files created (20 tests total): `JnaEmbeddedBackupTest`, `JnaServerBackupTest`, `PanamaEmbeddedBackupTest`, `PanamaServerBackupTest`. Each has 5 tests covering: sentinel copy, leaveClosed/leaveStopped, mode-rejection, null options, closed session guard. |
+| 5 | `BackupExecutor.execute()` copies source directory to destination, writes manifest JSON, and returns `BackupManifest` | VERIFIED | `BackupExecutor.java`: `Files.walkFileTree` copies files with SHA-256 hashing (`MessageDigest.getInstance("SHA-256")`), `writeManifest()` writes pretty-printed JSON to `backup_manifest.json`. `BackupExecutorTest` confirms copy, manifest parse, fileCount, totalBytes. |
+| 6 | Both JNA and Panama backends construct backup callback lambdas injected at session creation | VERIFIED | `JnaChromaRuntime.doStartEmbedded` line 126: `opts -> BackupExecutor.execute("embedded", ...)`. `doStartServer` line 143: `opts -> BackupExecutor.execute("server", ...)`. `PanamaChromaRuntime` mirrors identical pattern at lines 258 and 283. |
+
+**Score:** 6/6 truths verified
+
+---
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java` | Generic result type wrapping manifest + session | VERIFIED | 19 lines, `public final class BackupResult<S>`, two getters, `Objects.requireNonNull` on manifest |
+| `java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java` | Core backup algorithm | VERIFIED | 233 lines, `public static <S> BackupResult<S> execute(...)`, `Files.walkFileTree`, `MessageDigest.getInstance("SHA-256")`, `backup_manifest.json` |
+| `java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java` | All-args package-private constructor | VERIFIED | Two constructors: no-arg (Gson) and 12-param all-args at line 36 |
+| `java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java` | All-args package-private constructor | VERIFIED | Two constructors: no-arg (Gson) and 5-param all-args at line 18 |
+| `java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java` | 8-param constructor with backup callback slot | VERIFIED | 8-param constructor at line 19, `backup()` method at line 123 delegates to `backupAction.apply(options)` |
+| `java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java` | 7-param constructor with backup callback slot, no UnsupportedOperationException | VERIFIED | 7-param constructor at line 19, `backup()` at line 124 delegates to `backupAction.apply(options)`; no stub exception on backup |
+| `java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java` | Backup lambdas in doStartEmbedded and doStartServer | VERIFIED | `BackupExecutor.execute("embedded", ...)` at line 126; `BackupExecutor.execute("server", ...)` at line 143 |
+| `java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java` | Backup lambdas in doStartEmbedded and doStartServer | VERIFIED | `BackupExecutor.execute("embedded", ...)` at line 258; `BackupExecutor.execute("server", ...)` at line 283 |
+| `java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaEmbeddedBackupTest.java` | JNA embedded backup integration tests | VERIFIED | 146 lines, 5 test methods |
+| `java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaServerBackupTest.java` | JNA server backup integration tests | VERIFIED | 173 lines, 5 test methods |
+| `java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaEmbeddedBackupTest.java` | Panama embedded backup integration tests | VERIFIED | 146 lines, 5 test methods |
+| `java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaServerBackupTest.java` | Panama server backup integration tests | VERIFIED | 173 lines, 5 test methods |
+| `java/core/src/test/java/tech/amikos/chroma/local/core/BackupResultTest.java` | Unit tests for BackupResult | VERIFIED | 3 tests: accessors, null manifest rejection, null session allowed |
+| `java/core/src/test/java/tech/amikos/chroma/local/core/BackupExecutorTest.java` | Unit tests for backup algorithm | VERIFIED | 8 tests: copy+manifest, leaveClosed, mode rejections, dest-inside-source, non-empty dest, missing source, YAML extraction |
+
+---
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `EmbeddedSession.backup()` | `BackupResult<EmbeddedSession>` | `backupAction.apply(options)` | WIRED | Line 126: `return backupAction.apply(options)` |
+| `ServerSession.backup()` | `BackupResult<ServerSession>` | `backupAction.apply(options)` | WIRED | Line 127: `return backupAction.apply(options)` |
+| `JnaChromaRuntime.doStartEmbedded` | `BackupExecutor.execute` | backup lambda injected at session construction | WIRED | Line 126: `opts -> BackupExecutor.execute("embedded", persistPath, opts, ...)` |
+| `JnaChromaRuntime.doStartServer` | `BackupExecutor.execute` | backup lambda injected at session construction | WIRED | Line 143: `opts -> BackupExecutor.execute("server", persistPath, opts, ...)` |
+| `PanamaChromaRuntime.doStartEmbedded` | `BackupExecutor.execute` | backup lambda injected at session construction | WIRED | Line 258: `opts -> BackupExecutor.execute("embedded", persistPath, opts, ...)` |
+| `PanamaChromaRuntime.doStartServer` | `BackupExecutor.execute` | backup lambda injected at session construction | WIRED | Line 283: `opts -> BackupExecutor.execute("server", persistPath, opts, ...)` |
+
+---
+
+### Data-Flow Trace (Level 4)
+
+Level 4 is not applicable here. The artifacts are Java library types (no web rendering, no dashboard). The data flow is: `session.backup(options)` → `backupAction.apply(options)` → `BackupExecutor.execute(...)` → filesystem copy → `BackupResult<S>` returned to caller. The full chain was verified at Level 3 (wiring). The unit tests in `BackupExecutorTest` confirm the algorithm produces real file output, not static/empty results.
+
+---
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| Core module compiles and all unit tests pass | `gradle --no-daemon :core:test` | `BUILD SUCCESSFUL in 3s`, 2 tasks executed | PASS |
+| All three modules compile and lint-check | `gradle --no-daemon :core:check :jna:check :panama:check` | `BUILD SUCCESSFUL in 2s`, 10 tasks up-to-date | PASS |
+| Commit hashes from summaries exist in git log | `git log --oneline 305153d e47551a eeafe8d 9f99392` | All 4 commits present with matching descriptions | PASS |
+| Integration tests compile (JNA/Panama test classes) | Included in `:jna:check` and `:panama:check` above | Test classes compiled without error | PASS |
+
+Note: Integration tests (`JnaEmbeddedBackupTest`, `JnaServerBackupTest`, `PanamaEmbeddedBackupTest`, `PanamaServerBackupTest`) require `CHROMA_LIB_PATH` env var pointing to the built native shim. They use `Assumptions.assumeTrue` and will be skipped without FFI. Running them end-to-end requires a human with the built shim.
+
+---
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|------------|-------------|--------|----------|
+| BKUP-01 | 09-01-PLAN.md | `EmbeddedSession.backup(options)` performs directory copy with manifest and returns BackupManifest | SATISFIED | `EmbeddedSession.backup()` → `BackupExecutor.execute("embedded", ...)` → `BackupResult<EmbeddedSession>`. Integration tests verify sentinel copy and manifest content. |
+| BKUP-02 | 09-01-PLAN.md | `ServerSession.backup(options)` performs stop-backup-restart cycle and returns BackupManifest | SATISFIED | `ServerSession.backup()` → `BackupExecutor.execute("server", ...)` with `serverStop+serverFree` as closeAction and `doStartServer` as restartAction. Server backup tests assert new session port > 0. |
+| BKUP-03 | 09-01-PLAN.md | `BackupOptions` builder supports destination, includeMetadata, leaveClosed/leaveStopped | SATISFIED | `BackupOptions.Builder` has all four fields. `build()` validates `destinationPath`. Mode-specific flag validation in `BackupExecutor.validateModeOptions()`. Tests confirm leaveStopped rejected for embedded, leaveClosed rejected for server. |
+| BKUP-04 | 09-02-PLAN.md | Integration tests verify backup creates valid output directory in both backends | SATISFIED | 4 integration test files (20 tests) across JNA and Panama. Each test class covers: sentinel file copied to `dest/persist/`, `backup_manifest.json` present, manifest schema+mode assertions, leaveClosed/leaveStopped semantics, null options rejection, closed session guard. |
+
+All 4 BKUP requirements marked Complete in REQUIREMENTS.md. No orphaned requirements.
+
+---
+
+### Anti-Patterns Found
+
+No blocking or warning-level anti-patterns found.
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| `ServerSession.java` | 88, 97, 106, 111, 121 | `UnsupportedOperationException` for rebuildCollection, compactAll, compactCollection, pruneCollectionWAL, pruneAllWAL | Info | Intentional Phase 10 stubs for server maintenance operations — explicitly scoped out of Phase 9. `backup()` is fully implemented. No impact on BKUP requirements. |
+
+---
+
+### Human Verification Required
+
+The following require a built native shim (`CHROMA_LIB_PATH`) and a live Chroma runtime:
+
+**1. Embedded backup end-to-end with live FFI**
+
+Test: Build the Rust shim (`make build`), then run `CHROMA_LIB_PATH=shim/target/debug/libchroma_shim.dylib gradle --no-daemon :jna:test --tests '*JnaEmbeddedBackupTest*'`
+Expected: All 5 tests pass; `embeddedBackupCreatesDirectoryWithManifest` confirms `sentinel.txt` copied and manifest fileCount >= 1
+Why human: Requires a built native library that embeds a live Chroma runtime
+
+**2. Server backup stop-restart cycle with live FFI**
+
+Test: `CHROMA_LIB_PATH=... gradle --no-daemon :jna:test --tests '*JnaServerBackupTest*'`
+Expected: `serverBackupCreatesDirectoryWithManifest` passes; new `result.session().port() > 0` confirms server restarted successfully
+Why human: Requires native library; server start/stop touches OS-level port binding and process state
+
+**3. Panama backend end-to-end**
+
+Test: Same as items 1 and 2 but with Panama test classes
+Expected: Identical results to JNA (D-12 spec requires parity)
+Why human: Requires Java 22+ JVM with Panama FFI support and native library
+
+---
+
+### Gaps Summary
+
+No gaps. All 6 truths are verified, all artifacts exist and are substantive, all key links are wired, all 4 BKUP requirements are satisfied, and all automated checks pass. The three human verification items are end-to-end FFI integration tests that require a built native shim — they are the intended "integration test" coverage for BKUP-04. The test code is complete and correct; only execution against a live library is deferred to human verification.
+
+---
+
+_Verified: 2026-03-27_
+_Verifier: Claude (gsd-verifier)_

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
@@ -36,6 +36,10 @@ public final class BackupExecutor {
 
     private BackupExecutor() {}
 
+    static final class PreValidationFailure extends RuntimeException {
+        PreValidationFailure(RuntimeException cause) { super(cause); }
+    }
+
     public static <S> BackupResult<S> execute(BackupMode mode, String persistPath, String wrapperVersion,
                                               BackupOptions options, Runnable closeAction,
                                               Supplier<S> restartAction) {
@@ -46,15 +50,21 @@ public final class BackupExecutor {
         Objects.requireNonNull(closeAction, "closeAction");
         Objects.requireNonNull(restartAction, "restartAction");
 
-        Path dest = Path.of(options.destinationPath()).toAbsolutePath().normalize();
-        Path source = Path.of(persistPath).toAbsolutePath().normalize();
+        Path dest;
+        Path source;
+        try {
+            dest = Path.of(options.destinationPath()).toAbsolutePath().normalize();
+            source = Path.of(persistPath).toAbsolutePath().normalize();
 
-        if (isWithinPath(dest, source)) {
-            throw new IllegalArgumentException(
-                    "destination path cannot be inside source persist path: " + dest);
+            if (isWithinPath(dest, source)) {
+                throw new IllegalArgumentException(
+                        "destination path cannot be inside source persist path: " + dest);
+            }
+
+            ensureEmptyDir(dest);
+        } catch (RuntimeException e) {
+            throw new PreValidationFailure(e);
         }
-
-        ensureEmptyDir(dest);
 
         try {
             closeAction.run();

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
@@ -1,0 +1,233 @@
+package tech.amikos.chroma.local.core;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.yaml.snakeyaml.Yaml;
+
+final class BackupExecutor {
+
+    static final String MANIFEST_FILENAME = "backup_manifest.json";
+    static final String SNAPSHOT_DIRNAME = "persist";
+    static final String SCHEMA_VERSION = "v1";
+
+    private static final Gson PRETTY_GSON = new GsonBuilder()
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+            .setPrettyPrinting()
+            .create();
+
+    private BackupExecutor() {}
+
+    static <S> BackupResult<S> execute(String mode, String persistPath, BackupOptions options,
+                                       Runnable closeAction, Supplier<S> restartAction) {
+        validateModeOptions(mode, options);
+
+        Path dest = Path.of(options.destinationPath()).toAbsolutePath().normalize();
+        Path source = Path.of(persistPath).toAbsolutePath().normalize();
+
+        if (isWithinPath(dest, source)) {
+            throw new IllegalArgumentException(
+                    "destination path cannot be inside source persist path: " + dest);
+        }
+
+        ensureEmptyDir(dest);
+        closeAction.run();
+
+        try {
+            Path snapshotPath = dest.resolve(SNAPSHOT_DIRNAME);
+            CopyResult copyResult;
+            if (Files.isDirectory(source)) {
+                copyResult = copyDirectory(source, snapshotPath, options.includeMetadata());
+            } else {
+                Files.createDirectories(snapshotPath);
+                copyResult = new CopyResult(0, 0, List.of());
+            }
+
+            Path manifestPath = dest.resolve(MANIFEST_FILENAME);
+            BackupManifest manifest = new BackupManifest(
+                    SCHEMA_VERSION,
+                    mode,
+                    Instant.now().toString(),
+                    "java",
+                    List.of(source.toString()),
+                    dest.toString(),
+                    snapshotPath.toString(),
+                    manifestPath.toString(),
+                    options.includeMetadata(),
+                    copyResult.fileCount,
+                    copyResult.totalBytes,
+                    options.includeMetadata() ? copyResult.files : null);
+
+            writeManifest(manifestPath, manifest);
+
+            boolean leaveInactive = "embedded".equals(mode) ? options.leaveClosed() : options.leaveStopped();
+            if (leaveInactive) {
+                return new BackupResult<>(manifest, null);
+            }
+            S newSession = restartAction.get();
+            return new BackupResult<>(manifest, newSession);
+        } catch (IOException e) {
+            throw new ChromaException("backup failed: " + e.getMessage(), e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static String extractPersistPath(String configYaml) {
+        Yaml yaml = new Yaml();
+        Object loaded = yaml.load(configYaml);
+        if (!(loaded instanceof Map)) {
+            throw new IllegalArgumentException("invalid config YAML");
+        }
+        Map<String, Object> map = (Map<String, Object>) loaded;
+        Object persistPath = map.get("persist_path");
+        if (persistPath == null) {
+            Object chroma = map.get("chroma");
+            if (chroma instanceof Map) {
+                persistPath = ((Map<String, Object>) chroma).get("persist_path");
+            }
+        }
+        if (persistPath == null) {
+            throw new IllegalArgumentException("persist_path not found in config YAML");
+        }
+        return persistPath.toString();
+    }
+
+    private static void validateModeOptions(String mode, BackupOptions options) {
+        if ("embedded".equals(mode) && options.leaveStopped()) {
+            throw new IllegalArgumentException("leaveStopped is only valid for server backups");
+        }
+        if ("server".equals(mode) && options.leaveClosed()) {
+            throw new IllegalArgumentException("leaveClosed is only valid for embedded backups");
+        }
+    }
+
+    private static boolean isWithinPath(Path path, Path parent) {
+        Path normalized = path.toAbsolutePath().normalize();
+        Path normalizedParent = parent.toAbsolutePath().normalize();
+        return normalized.startsWith(normalizedParent);
+    }
+
+    private static void ensureEmptyDir(Path path) {
+        try {
+            if (Files.exists(path)) {
+                if (!Files.isDirectory(path)) {
+                    throw new IllegalArgumentException("destination path must be a directory: " + path);
+                }
+                try (var entries = Files.list(path)) {
+                    if (entries.findFirst().isPresent()) {
+                        throw new IllegalArgumentException("destination path must be empty: " + path);
+                    }
+                }
+            } else {
+                Files.createDirectories(path);
+            }
+        } catch (IOException e) {
+            throw new ChromaException("failed to prepare destination directory: " + e.getMessage(), e);
+        }
+    }
+
+    private static CopyResult copyDirectory(Path source, Path destination, boolean includeMetadata)
+            throws IOException {
+        Files.createDirectories(destination);
+        List<BackupFileMetadata> files = new ArrayList<>();
+        int[] fileCount = {0};
+        long[] totalBytes = {0};
+
+        Files.walkFileTree(source, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                    throws IOException {
+                Path target = destination.resolve(source.relativize(dir));
+                Files.createDirectories(target);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                    throws IOException {
+                if (Files.isSymbolicLink(file)) {
+                    throw new IOException("backup does not support symbolic links: " + file);
+                }
+                Path target = destination.resolve(source.relativize(file));
+                String sha256 = copyFileWithHash(file, target);
+                fileCount[0]++;
+                totalBytes[0] += attrs.size();
+                if (includeMetadata) {
+                    String relPath = source.relativize(file).toString().replace('\\', '/');
+                    String mode = readFileMode(file);
+                    String modifiedAt = attrs.lastModifiedTime().toInstant().toString();
+                    files.add(new BackupFileMetadata(relPath, attrs.size(), mode, sha256, modifiedAt));
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        return new CopyResult(fileCount[0], totalBytes[0], files);
+    }
+
+    private static String copyFileWithHash(Path source, Path destination) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] buffer = new byte[8192];
+            try (InputStream in = Files.newInputStream(source);
+                 OutputStream out = Files.newOutputStream(destination,
+                         StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, read);
+                    digest.update(buffer, 0, read);
+                }
+            }
+            Files.setLastModifiedTime(destination, Files.getLastModifiedTime(source));
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException("SHA-256 not available", e);
+        }
+    }
+
+    private static String readFileMode(Path file) {
+        try {
+            var perms = Files.getPosixFilePermissions(file);
+            String permStr = PosixFilePermissions.toString(perms);
+            int mode = 0;
+            if (permStr.charAt(0) == 'r') mode |= 0400;
+            if (permStr.charAt(1) == 'w') mode |= 0200;
+            if (permStr.charAt(2) == 'x') mode |= 0100;
+            if (permStr.charAt(3) == 'r') mode |= 040;
+            if (permStr.charAt(4) == 'w') mode |= 020;
+            if (permStr.charAt(5) == 'x') mode |= 010;
+            if (permStr.charAt(6) == 'r') mode |= 04;
+            if (permStr.charAt(7) == 'w') mode |= 02;
+            if (permStr.charAt(8) == 'x') mode |= 01;
+            return String.format("0%o", mode);
+        } catch (UnsupportedOperationException | IOException e) {
+            return "0644";
+        }
+    }
+
+    private static void writeManifest(Path manifestPath, BackupManifest manifest) throws IOException {
+        String json = PRETTY_GSON.toJson(manifest) + "\n";
+        Files.writeString(manifestPath, json, StandardOpenOption.CREATE_NEW);
+    }
+
+    private record CopyResult(int fileCount, long totalBytes, List<BackupFileMetadata> files) {}
+}

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
@@ -20,11 +20,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
-
-import org.yaml.snakeyaml.Yaml;
 
 public final class BackupExecutor {
 
@@ -39,10 +36,12 @@ public final class BackupExecutor {
 
     private BackupExecutor() {}
 
-    public static <S> BackupResult<S> execute(BackupMode mode, String persistPath, BackupOptions options,
-                                              Runnable closeAction, Supplier<S> restartAction) {
+    public static <S> BackupResult<S> execute(BackupMode mode, String persistPath, String wrapperVersion,
+                                              BackupOptions options, Runnable closeAction,
+                                              Supplier<S> restartAction) {
         Objects.requireNonNull(mode, "mode");
         Objects.requireNonNull(persistPath, "persistPath");
+        Objects.requireNonNull(wrapperVersion, "wrapperVersion");
         Objects.requireNonNull(options, "options");
         Objects.requireNonNull(closeAction, "closeAction");
         Objects.requireNonNull(restartAction, "restartAction");
@@ -82,7 +81,7 @@ public final class BackupExecutor {
                     SCHEMA_VERSION,
                     mode.toWire(),
                     Instant.now().toString(),
-                    "java",
+                    wrapperVersion,
                     List.of(source.toString()),
                     dest.toString(),
                     snapshotPath.toString(),
@@ -123,6 +122,8 @@ public final class BackupExecutor {
         }
 
         if (backupError != null) {
+            IOException cleanupErr = deleteDirectoryQuietly(dest);
+            if (cleanupErr != null) backupError.addSuppressed(cleanupErr);
             throw toRuntimeException(backupError);
         }
 
@@ -132,32 +133,6 @@ public final class BackupExecutor {
     private static RuntimeException toRuntimeException(Throwable t) {
         if (t instanceof RuntimeException re) return re;
         return new ChromaException("backup failed: " + t.getMessage(), t);
-    }
-
-    @SuppressWarnings("unchecked")
-    public static String extractPersistPath(String configYaml) {
-        Yaml yaml = new Yaml();
-        Object loaded;
-        try {
-            loaded = yaml.load(configYaml);
-        } catch (RuntimeException e) {
-            throw new IllegalArgumentException("invalid config YAML: " + e.getMessage(), e);
-        }
-        if (!(loaded instanceof Map)) {
-            throw new IllegalArgumentException("invalid config YAML");
-        }
-        Map<String, Object> map = (Map<String, Object>) loaded;
-        Object persistPath = map.get("persist_path");
-        if (persistPath == null) {
-            Object chroma = map.get("chroma");
-            if (chroma instanceof Map) {
-                persistPath = ((Map<String, Object>) chroma).get("persist_path");
-            }
-        }
-        if (persistPath == null) {
-            throw new IllegalArgumentException("persist_path not found in config YAML");
-        }
-        return persistPath.toString();
     }
 
     private static boolean isWithinPath(Path path, Path parent) {

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
 
 import org.yaml.snakeyaml.Yaml;
 
-final class BackupExecutor {
+public final class BackupExecutor {
 
     static final String MANIFEST_FILENAME = "backup_manifest.json";
     static final String SNAPSHOT_DIRNAME = "persist";
@@ -38,8 +38,8 @@ final class BackupExecutor {
 
     private BackupExecutor() {}
 
-    static <S> BackupResult<S> execute(String mode, String persistPath, BackupOptions options,
-                                       Runnable closeAction, Supplier<S> restartAction) {
+    public static <S> BackupResult<S> execute(String mode, String persistPath, BackupOptions options,
+                                              Runnable closeAction, Supplier<S> restartAction) {
         validateModeOptions(mode, options);
 
         Path dest = Path.of(options.destinationPath()).toAbsolutePath().normalize();
@@ -92,7 +92,7 @@ final class BackupExecutor {
     }
 
     @SuppressWarnings("unchecked")
-    static String extractPersistPath(String configYaml) {
+    public static String extractPersistPath(String configYaml) {
         Yaml yaml = new Yaml();
         Object loaded = yaml.load(configYaml);
         if (!(loaded instanceof Map)) {

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupExecutor.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.yaml.snakeyaml.Yaml;
@@ -38,9 +39,13 @@ public final class BackupExecutor {
 
     private BackupExecutor() {}
 
-    public static <S> BackupResult<S> execute(String mode, String persistPath, BackupOptions options,
+    public static <S> BackupResult<S> execute(BackupMode mode, String persistPath, BackupOptions options,
                                               Runnable closeAction, Supplier<S> restartAction) {
-        validateModeOptions(mode, options);
+        Objects.requireNonNull(mode, "mode");
+        Objects.requireNonNull(persistPath, "persistPath");
+        Objects.requireNonNull(options, "options");
+        Objects.requireNonNull(closeAction, "closeAction");
+        Objects.requireNonNull(restartAction, "restartAction");
 
         Path dest = Path.of(options.destinationPath()).toAbsolutePath().normalize();
         Path source = Path.of(persistPath).toAbsolutePath().normalize();
@@ -51,22 +56,31 @@ public final class BackupExecutor {
         }
 
         ensureEmptyDir(dest);
-        closeAction.run();
 
+        try {
+            closeAction.run();
+        } catch (RuntimeException e) {
+            IOException cleanupErr = deleteDirectoryQuietly(dest);
+            if (cleanupErr != null) e.addSuppressed(cleanupErr);
+            throw e;
+        }
+
+        IOException backupError = null;
+        BackupManifest manifest = null;
         try {
             Path snapshotPath = dest.resolve(SNAPSHOT_DIRNAME);
             CopyResult copyResult;
             if (Files.isDirectory(source)) {
                 copyResult = copyDirectory(source, snapshotPath, options.includeMetadata());
             } else {
-                Files.createDirectories(snapshotPath);
-                copyResult = new CopyResult(0, 0, List.of());
+                throw new IOException(
+                        "backup source path does not exist or is not a directory: " + source);
             }
 
             Path manifestPath = dest.resolve(MANIFEST_FILENAME);
-            BackupManifest manifest = new BackupManifest(
+            manifest = new BackupManifest(
                     SCHEMA_VERSION,
-                    mode,
+                    mode.toWire(),
                     Instant.now().toString(),
                     "java",
                     List.of(source.toString()),
@@ -79,22 +93,56 @@ public final class BackupExecutor {
                     options.includeMetadata() ? copyResult.files : null);
 
             writeManifest(manifestPath, manifest);
-
-            boolean leaveInactive = "embedded".equals(mode) ? options.leaveClosed() : options.leaveStopped();
-            if (leaveInactive) {
-                return new BackupResult<>(manifest, null);
-            }
-            S newSession = restartAction.get();
-            return new BackupResult<>(manifest, newSession);
         } catch (IOException e) {
-            throw new ChromaException("backup failed: " + e.getMessage(), e);
+            backupError = e;
         }
+
+        if (options.leaveInactive()) {
+            if (backupError != null) {
+                IOException cleanupErr = deleteDirectoryQuietly(dest);
+                if (cleanupErr != null) backupError.addSuppressed(cleanupErr);
+                throw toRuntimeException(backupError);
+            }
+            return new BackupResult<>(manifest, null);
+        }
+
+        S newSession;
+        try {
+            newSession = restartAction.get();
+        } catch (RuntimeException restartErr) {
+            if (backupError != null) {
+                IOException cleanupErr = deleteDirectoryQuietly(dest);
+                if (cleanupErr != null) backupError.addSuppressed(cleanupErr);
+            }
+            ChromaException combined = new ChromaException(
+                    "backup failed and restart also failed: " + restartErr.getMessage(), restartErr);
+            if (backupError != null) {
+                combined.addSuppressed(backupError);
+            }
+            throw combined;
+        }
+
+        if (backupError != null) {
+            throw toRuntimeException(backupError);
+        }
+
+        return new BackupResult<>(manifest, newSession);
+    }
+
+    private static RuntimeException toRuntimeException(Throwable t) {
+        if (t instanceof RuntimeException re) return re;
+        return new ChromaException("backup failed: " + t.getMessage(), t);
     }
 
     @SuppressWarnings("unchecked")
     public static String extractPersistPath(String configYaml) {
         Yaml yaml = new Yaml();
-        Object loaded = yaml.load(configYaml);
+        Object loaded;
+        try {
+            loaded = yaml.load(configYaml);
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("invalid config YAML: " + e.getMessage(), e);
+        }
         if (!(loaded instanceof Map)) {
             throw new IllegalArgumentException("invalid config YAML");
         }
@@ -110,15 +158,6 @@ public final class BackupExecutor {
             throw new IllegalArgumentException("persist_path not found in config YAML");
         }
         return persistPath.toString();
-    }
-
-    private static void validateModeOptions(String mode, BackupOptions options) {
-        if ("embedded".equals(mode) && options.leaveStopped()) {
-            throw new IllegalArgumentException("leaveStopped is only valid for server backups");
-        }
-        if ("server".equals(mode) && options.leaveClosed()) {
-            throw new IllegalArgumentException("leaveClosed is only valid for embedded backups");
-        }
     }
 
     private static boolean isWithinPath(Path path, Path parent) {
@@ -204,7 +243,7 @@ public final class BackupExecutor {
         }
     }
 
-    private static String readFileMode(Path file) {
+    private static String readFileMode(Path file) throws IOException {
         try {
             var perms = Files.getPosixFilePermissions(file);
             String permStr = PosixFilePermissions.toString(perms);
@@ -219,8 +258,31 @@ public final class BackupExecutor {
             if (permStr.charAt(7) == 'w') mode |= 02;
             if (permStr.charAt(8) == 'x') mode |= 01;
             return String.format("0%o", mode);
-        } catch (UnsupportedOperationException | IOException e) {
+        } catch (UnsupportedOperationException e) {
             return "0644";
+        }
+    }
+
+    static IOException deleteDirectoryQuietly(Path dir) {
+        try {
+            if (!Files.exists(dir)) return null;
+            Files.walkFileTree(dir, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.deleteIfExists(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path d, IOException exc) throws IOException {
+                    if (exc != null) throw exc;
+                    Files.deleteIfExists(d);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+            return null;
+        } catch (IOException e) {
+            return e;
         }
     }
 

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java
@@ -15,6 +15,14 @@ public final class BackupFileMetadata {
         this.modifiedAt = null;
     }
 
+    BackupFileMetadata(String path, long sizeBytes, String mode, String sha256, String modifiedAt) {
+        this.path = path;
+        this.sizeBytes = sizeBytes;
+        this.mode = mode;
+        this.sha256 = sha256;
+        this.modifiedAt = modifiedAt;
+    }
+
     public String path() { return path; }
     public long sizeBytes() { return sizeBytes; }
     public String mode() { return mode; }

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java
@@ -1,31 +1,13 @@
 package tech.amikos.chroma.local.core;
 
-public final class BackupFileMetadata {
-    private final String path;
-    private final long sizeBytes;
-    private final String mode;
-    private final String sha256;
-    private final String modifiedAt;
+import java.util.Objects;
 
-    BackupFileMetadata() {
-        this.path = null;
-        this.sizeBytes = 0;
-        this.mode = null;
-        this.sha256 = null;
-        this.modifiedAt = null;
+public record BackupFileMetadata(String path, long sizeBytes, String mode, String sha256, String modifiedAt) {
+    public BackupFileMetadata {
+        Objects.requireNonNull(path, "path");
+        if (sizeBytes < 0) throw new IllegalArgumentException("sizeBytes must be non-negative");
+        Objects.requireNonNull(sha256, "sha256");
+        Objects.requireNonNull(modifiedAt, "modifiedAt");
+        // mode is intentionally nullable (fallback "0644" on non-POSIX systems)
     }
-
-    BackupFileMetadata(String path, long sizeBytes, String mode, String sha256, String modifiedAt) {
-        this.path = path;
-        this.sizeBytes = sizeBytes;
-        this.mode = mode;
-        this.sha256 = sha256;
-        this.modifiedAt = modifiedAt;
-    }
-
-    public String path() { return path; }
-    public long sizeBytes() { return sizeBytes; }
-    public String mode() { return mode; }
-    public String sha256() { return sha256; }
-    public String modifiedAt() { return modifiedAt; }
 }

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupFileMetadata.java
@@ -6,8 +6,8 @@ public record BackupFileMetadata(String path, long sizeBytes, String mode, Strin
     public BackupFileMetadata {
         Objects.requireNonNull(path, "path");
         if (sizeBytes < 0) throw new IllegalArgumentException("sizeBytes must be non-negative");
+        Objects.requireNonNull(mode, "mode");
         Objects.requireNonNull(sha256, "sha256");
         Objects.requireNonNull(modifiedAt, "modifiedAt");
-        // mode is intentionally nullable (fallback "0644" on non-POSIX systems)
     }
 }

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java
@@ -1,5 +1,6 @@
 package tech.amikos.chroma.local.core;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -30,6 +31,24 @@ public final class BackupManifest {
         this.fileCount = 0;
         this.totalBytes = 0;
         this.files = null;
+    }
+
+    BackupManifest(String schemaVersion, String mode, String createdAt, String wrapperVersion,
+                   List<String> sourcePaths, String destinationPath, String snapshotPath,
+                   String manifestPath, boolean includeMetadata, int fileCount, long totalBytes,
+                   List<BackupFileMetadata> files) {
+        this.schemaVersion = schemaVersion;
+        this.mode = mode;
+        this.createdAt = createdAt;
+        this.wrapperVersion = wrapperVersion;
+        this.sourcePaths = sourcePaths == null ? null : new ArrayList<>(sourcePaths);
+        this.destinationPath = destinationPath;
+        this.snapshotPath = snapshotPath;
+        this.manifestPath = manifestPath;
+        this.includeMetadata = includeMetadata;
+        this.fileCount = fileCount;
+        this.totalBytes = totalBytes;
+        this.files = files == null ? null : new ArrayList<>(files);
     }
 
     public String schemaVersion() { return schemaVersion; }

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupManifest.java
@@ -3,6 +3,7 @@ package tech.amikos.chroma.local.core;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public final class BackupManifest {
     private final String schemaVersion;
@@ -18,35 +19,22 @@ public final class BackupManifest {
     private final long totalBytes;
     private final List<BackupFileMetadata> files;
 
-    BackupManifest() {
-        this.schemaVersion = null;
-        this.mode = null;
-        this.createdAt = null;
-        this.wrapperVersion = null;
-        this.sourcePaths = null;
-        this.destinationPath = null;
-        this.snapshotPath = null;
-        this.manifestPath = null;
-        this.includeMetadata = false;
-        this.fileCount = 0;
-        this.totalBytes = 0;
-        this.files = null;
-    }
-
     BackupManifest(String schemaVersion, String mode, String createdAt, String wrapperVersion,
                    List<String> sourcePaths, String destinationPath, String snapshotPath,
                    String manifestPath, boolean includeMetadata, int fileCount, long totalBytes,
                    List<BackupFileMetadata> files) {
-        this.schemaVersion = schemaVersion;
-        this.mode = mode;
-        this.createdAt = createdAt;
-        this.wrapperVersion = wrapperVersion;
-        this.sourcePaths = sourcePaths == null ? null : new ArrayList<>(sourcePaths);
-        this.destinationPath = destinationPath;
-        this.snapshotPath = snapshotPath;
-        this.manifestPath = manifestPath;
+        this.schemaVersion = Objects.requireNonNull(schemaVersion, "schemaVersion");
+        this.mode = Objects.requireNonNull(mode, "mode");
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt");
+        this.wrapperVersion = Objects.requireNonNull(wrapperVersion, "wrapperVersion");
+        this.sourcePaths = new ArrayList<>(Objects.requireNonNull(sourcePaths, "sourcePaths"));
+        this.destinationPath = Objects.requireNonNull(destinationPath, "destinationPath");
+        this.snapshotPath = Objects.requireNonNull(snapshotPath, "snapshotPath");
+        this.manifestPath = Objects.requireNonNull(manifestPath, "manifestPath");
         this.includeMetadata = includeMetadata;
+        if (fileCount < 0) throw new IllegalArgumentException("fileCount must be non-negative");
         this.fileCount = fileCount;
+        if (totalBytes < 0) throw new IllegalArgumentException("totalBytes must be non-negative");
         this.totalBytes = totalBytes;
         this.files = files == null ? null : new ArrayList<>(files);
     }
@@ -55,7 +43,7 @@ public final class BackupManifest {
     public String mode() { return mode; }
     public String createdAt() { return createdAt; }
     public String wrapperVersion() { return wrapperVersion; }
-    public List<String> sourcePaths() { return sourcePaths == null ? Collections.emptyList() : Collections.unmodifiableList(sourcePaths); }
+    public List<String> sourcePaths() { return Collections.unmodifiableList(sourcePaths); }
     public String destinationPath() { return destinationPath; }
     public String snapshotPath() { return snapshotPath; }
     public String manifestPath() { return manifestPath; }

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupMode.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupMode.java
@@ -1,0 +1,16 @@
+package tech.amikos.chroma.local.core;
+
+public enum BackupMode {
+    SERVER("server"),
+    EMBEDDED("embedded");
+
+    private final String wire;
+
+    BackupMode(String wire) {
+        this.wire = wire;
+    }
+
+    public String toWire() {
+        return wire;
+    }
+}

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupOptions.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupOptions.java
@@ -4,30 +4,22 @@ public final class BackupOptions {
 
     private final String destinationPath;
     private final boolean includeMetadata;
-    private final boolean leaveStopped;
-    private final boolean leaveClosed;
+    private final boolean leaveInactive;
 
     private BackupOptions(Builder builder) {
         this.destinationPath = builder.destinationPath;
         this.includeMetadata = builder.includeMetadata;
-        this.leaveStopped = builder.leaveStopped;
-        this.leaveClosed = builder.leaveClosed;
+        this.leaveInactive = builder.leaveInactive;
     }
 
     public String destinationPath() { return destinationPath; }
     public boolean includeMetadata() { return includeMetadata; }
-    public boolean leaveStopped() { return leaveStopped; }
-    public boolean leaveClosed() { return leaveClosed; }
-
-    public String toJson() {
-        return JsonUtil.toJson(this);
-    }
+    public boolean leaveInactive() { return leaveInactive; }
 
     public static class Builder {
         private final String destinationPath;
         private boolean includeMetadata;
-        private boolean leaveStopped;
-        private boolean leaveClosed;
+        private boolean leaveInactive;
 
         public Builder(String destinationPath) {
             this.destinationPath = destinationPath;
@@ -38,19 +30,14 @@ public final class BackupOptions {
             return this;
         }
 
-        public Builder leaveStopped(boolean leaveStopped) {
-            this.leaveStopped = leaveStopped;
-            return this;
-        }
-
-        public Builder leaveClosed(boolean leaveClosed) {
-            this.leaveClosed = leaveClosed;
+        public Builder leaveInactive(boolean leaveInactive) {
+            this.leaveInactive = leaveInactive;
             return this;
         }
 
         public BackupOptions build() {
             if (destinationPath == null || destinationPath.isBlank()) {
-                throw new IllegalArgumentException("destination_path is required");
+                throw new IllegalArgumentException("destinationPath is required");
             }
             return new BackupOptions(this);
         }

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java
@@ -2,17 +2,9 @@ package tech.amikos.chroma.local.core;
 
 import java.util.Objects;
 
-public final class BackupResult<S> {
-    private final BackupManifest manifest;
-    private final S session;
-
-    public BackupResult(BackupManifest manifest, S session) {
-        this.manifest = Objects.requireNonNull(manifest, "manifest");
-        this.session = session;
+/** @param session the new session, or null when backup was configured to leave the system inactive */
+public record BackupResult<S>(BackupManifest manifest, S session) {
+    public BackupResult {
+        Objects.requireNonNull(manifest, "manifest");
     }
-
-    public BackupManifest manifest() { return manifest; }
-
-    /** Returns the new session after backup, or null if left closed/stopped. */
-    public S session() { return session; }
 }

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/BackupResult.java
@@ -1,0 +1,18 @@
+package tech.amikos.chroma.local.core;
+
+import java.util.Objects;
+
+public final class BackupResult<S> {
+    private final BackupManifest manifest;
+    private final S session;
+
+    public BackupResult(BackupManifest manifest, S session) {
+        this.manifest = Objects.requireNonNull(manifest, "manifest");
+        this.session = session;
+    }
+
+    public BackupManifest manifest() { return manifest; }
+
+    /** Returns the new session after backup, or null if left closed/stopped. */
+    public S session() { return session; }
+}

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java
@@ -1,6 +1,7 @@
 package tech.amikos.chroma.local.core;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
@@ -9,6 +10,7 @@ public final class EmbeddedSession implements AutoCloseable {
     private final long handle;
     private final LongConsumer closeAction;
     private final AtomicBoolean closed;
+    private final ReentrantLock backupLock = new ReentrantLock();
     private final BiFunction<Long, String, RebuildCollectionResult> rebuildAction;
     private final BiFunction<Long, String, CompactionResult> compactCollectionAction;
     private final BiFunction<Long, String, CompactionResult> compactAllAction;
@@ -111,7 +113,7 @@ public final class EmbeddedSession implements AutoCloseable {
         return pruneCollectionWAL(WALPruneOptions.defaults(name));
     }
 
-    /** Prunes WAL rows for all collections. The {@code name} field in options is ignored. */
+    /** The {@code name} field in options is ignored. */
     public WALPruneResult pruneAllWAL(WALPruneOptions options) {
         ensureOpen();
         if (options == null) {
@@ -121,15 +123,29 @@ public final class EmbeddedSession implements AutoCloseable {
     }
 
     public BackupResult<EmbeddedSession> backup(BackupOptions options) {
-        ensureOpen();
-        if (options == null) throw new IllegalArgumentException("options is required");
-        return backupAction.apply(options);
+        backupLock.lock();
+        try {
+            ensureOpen();
+            if (options == null) throw new IllegalArgumentException("options is required");
+            try {
+                return backupAction.apply(options);
+            } finally {
+                closed.set(true);
+            }
+        } finally {
+            backupLock.unlock();
+        }
     }
 
     @Override
     public void close() {
-        if (closed.compareAndSet(false, true)) {
-            closeAction.accept(handle);
+        backupLock.lock();
+        try {
+            if (closed.compareAndSet(false, true)) {
+                closeAction.accept(handle);
+            }
+        } finally {
+            backupLock.unlock();
         }
     }
 }

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java
@@ -2,6 +2,7 @@ package tech.amikos.chroma.local.core;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.LongConsumer;
 
 public final class EmbeddedSession implements AutoCloseable {
@@ -13,13 +14,15 @@ public final class EmbeddedSession implements AutoCloseable {
     private final BiFunction<Long, String, CompactionResult> compactAllAction;
     private final BiFunction<Long, String, WALPruneResult> pruneWalCollectionAction;
     private final BiFunction<Long, String, WALPruneResult> pruneWalAllAction;
+    private final Function<BackupOptions, BackupResult<EmbeddedSession>> backupAction;
 
     public EmbeddedSession(long handle, LongConsumer closeAction,
             BiFunction<Long, String, RebuildCollectionResult> rebuildAction,
             BiFunction<Long, String, CompactionResult> compactCollectionAction,
             BiFunction<Long, String, CompactionResult> compactAllAction,
             BiFunction<Long, String, WALPruneResult> pruneWalCollectionAction,
-            BiFunction<Long, String, WALPruneResult> pruneWalAllAction) {
+            BiFunction<Long, String, WALPruneResult> pruneWalAllAction,
+            Function<BackupOptions, BackupResult<EmbeddedSession>> backupAction) {
         if (handle == 0L) {
             throw new IllegalArgumentException("embedded handle must be non-zero");
         }
@@ -41,6 +44,9 @@ public final class EmbeddedSession implements AutoCloseable {
         if (pruneWalAllAction == null) {
             throw new IllegalArgumentException("pruneWalAllAction must be set");
         }
+        if (backupAction == null) {
+            throw new IllegalArgumentException("backupAction must be set");
+        }
         this.handle = handle;
         this.closeAction = closeAction;
         this.closed = new AtomicBoolean(false);
@@ -49,6 +55,7 @@ public final class EmbeddedSession implements AutoCloseable {
         this.compactAllAction = compactAllAction;
         this.pruneWalCollectionAction = pruneWalCollectionAction;
         this.pruneWalAllAction = pruneWalAllAction;
+        this.backupAction = backupAction;
     }
 
     private void ensureOpen() {
@@ -111,6 +118,12 @@ public final class EmbeddedSession implements AutoCloseable {
             throw new IllegalArgumentException("options is required");
         }
         return pruneWalAllAction.apply(handle, options.toJson());
+    }
+
+    public BackupResult<EmbeddedSession> backup(BackupOptions options) {
+        ensureOpen();
+        if (options == null) throw new IllegalArgumentException("options is required");
+        return backupAction.apply(options);
     }
 
     @Override

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/EmbeddedSession.java
@@ -128,9 +128,14 @@ public final class EmbeddedSession implements AutoCloseable {
             ensureOpen();
             if (options == null) throw new IllegalArgumentException("options is required");
             try {
-                return backupAction.apply(options);
-            } finally {
+                BackupResult<EmbeddedSession> result = backupAction.apply(options);
                 closed.set(true);
+                return result;
+            } catch (BackupExecutor.PreValidationFailure e) {
+                throw (RuntimeException) e.getCause();
+            } catch (RuntimeException e) {
+                closed.set(true);
+                throw e;
             }
         } finally {
             backupLock.unlock();

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java
@@ -1,6 +1,7 @@
 package tech.amikos.chroma.local.core;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.function.LongFunction;
@@ -9,6 +10,7 @@ import java.util.function.LongToIntFunction;
 public final class ServerSession implements AutoCloseable {
     private final long handle;
     private final AtomicBoolean closed;
+    private final ReentrantLock backupLock = new ReentrantLock();
     private final LongConsumer stopAction;
     private final LongConsumer freeAction;
     private final LongToIntFunction portAccessor;
@@ -49,32 +51,37 @@ public final class ServerSession implements AutoCloseable {
 
     public String persistPath() { ensureOpen(); return persistPathAccessor.apply(handle); }
 
-    // TLS not yet supported — plain HTTP only (see issue tracker for self-signed cert support)
+    // TLS not yet supported
     public String url() {
         return "http://" + address() + ":" + port();
     }
 
     @Override
     public void close() {
-        if (closed.compareAndSet(false, true)) {
-            Throwable stopError = null;
-            try {
-                stopAction.accept(handle);
-            } catch (Throwable t) {
-                stopError = t;
-            }
-            try {
-                freeAction.accept(handle);
-            } catch (Throwable t) {
+        backupLock.lock();
+        try {
+            if (closed.compareAndSet(false, true)) {
+                Throwable stopError = null;
+                try {
+                    stopAction.accept(handle);
+                } catch (Throwable t) {
+                    stopError = t;
+                }
+                try {
+                    freeAction.accept(handle);
+                } catch (Throwable t) {
+                    if (stopError != null) {
+                        stopError.addSuppressed(t);
+                        throw rethrow(stopError);
+                    }
+                    throw rethrow(t);
+                }
                 if (stopError != null) {
-                    stopError.addSuppressed(t);
                     throw rethrow(stopError);
                 }
-                throw rethrow(t);
             }
-            if (stopError != null) {
-                throw rethrow(stopError);
-            }
+        } finally {
+            backupLock.unlock();
         }
     }
 
@@ -85,7 +92,7 @@ public final class ServerSession implements AutoCloseable {
 
     public RebuildCollectionResult rebuildCollection(RebuildOptions options) {
         ensureOpen();
-        throw new UnsupportedOperationException("rebuildCollection will be wired in Phase 10");
+        throw new UnsupportedOperationException("rebuildCollection is not yet supported for server sessions");
     }
 
     public RebuildCollectionResult rebuildCollection(String name) {
@@ -94,7 +101,7 @@ public final class ServerSession implements AutoCloseable {
 
     public CompactionResult compactCollection(CompactCollectionRequest request) {
         ensureOpen();
-        throw new UnsupportedOperationException("compactCollection will be wired in Phase 10");
+        throw new UnsupportedOperationException("compactCollection is not yet supported for server sessions");
     }
 
     public CompactionResult compactCollection(String name) {
@@ -103,27 +110,36 @@ public final class ServerSession implements AutoCloseable {
 
     public CompactionResult compactAll(CompactAllRequest request) {
         ensureOpen();
-        throw new UnsupportedOperationException("compactAll will be wired in Phase 10");
+        throw new UnsupportedOperationException("compactAll is not yet supported for server sessions");
     }
 
     public WALPruneResult pruneCollectionWAL(WALPruneOptions options) {
         ensureOpen();
-        throw new UnsupportedOperationException("pruneCollectionWAL will be wired in Phase 10");
+        throw new UnsupportedOperationException("pruneCollectionWAL is not yet supported for server sessions");
     }
 
     public WALPruneResult pruneCollectionWAL(String name) {
         return pruneCollectionWAL(WALPruneOptions.defaults(name));
     }
 
-    /** Prunes WAL rows for all collections. The {@code name} field in options is ignored. */
+    /** The {@code name} field in options is ignored. */
     public WALPruneResult pruneAllWAL(WALPruneOptions options) {
         ensureOpen();
-        throw new UnsupportedOperationException("pruneAllWAL will be wired in Phase 10");
+        throw new UnsupportedOperationException("pruneAllWAL is not yet supported for server sessions");
     }
 
     public BackupResult<ServerSession> backup(BackupOptions options) {
-        ensureOpen();
-        if (options == null) throw new IllegalArgumentException("options is required");
-        return backupAction.apply(options);
+        backupLock.lock();
+        try {
+            ensureOpen();
+            if (options == null) throw new IllegalArgumentException("options is required");
+            try {
+                return backupAction.apply(options);
+            } finally {
+                closed.set(true);
+            }
+        } finally {
+            backupLock.unlock();
+        }
     }
 }

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java
@@ -134,9 +134,14 @@ public final class ServerSession implements AutoCloseable {
             ensureOpen();
             if (options == null) throw new IllegalArgumentException("options is required");
             try {
-                return backupAction.apply(options);
-            } finally {
+                BackupResult<ServerSession> result = backupAction.apply(options);
                 closed.set(true);
+                return result;
+            } catch (BackupExecutor.PreValidationFailure e) {
+                throw (RuntimeException) e.getCause();
+            } catch (RuntimeException e) {
+                closed.set(true);
+                throw e;
             }
         } finally {
             backupLock.unlock();

--- a/java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java
+++ b/java/core/src/main/java/tech/amikos/chroma/local/core/ServerSession.java
@@ -1,6 +1,7 @@
 package tech.amikos.chroma.local.core;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.function.LongFunction;
 import java.util.function.LongToIntFunction;
@@ -13,22 +14,26 @@ public final class ServerSession implements AutoCloseable {
     private final LongToIntFunction portAccessor;
     private final LongFunction<String> addressAccessor;
     private final LongFunction<String> persistPathAccessor;
+    private final Function<BackupOptions, BackupResult<ServerSession>> backupAction;
 
     public ServerSession(long handle, LongConsumer stopAction, LongConsumer freeAction,
                          LongToIntFunction portAccessor, LongFunction<String> addressAccessor,
-                         LongFunction<String> persistPathAccessor) {
+                         LongFunction<String> persistPathAccessor,
+                         Function<BackupOptions, BackupResult<ServerSession>> backupAction) {
         if (handle == 0L) throw new IllegalArgumentException("server handle must be non-zero");
         if (stopAction == null) throw new IllegalArgumentException("stopAction must be set");
         if (freeAction == null) throw new IllegalArgumentException("freeAction must be set");
         if (portAccessor == null) throw new IllegalArgumentException("portAccessor must be set");
         if (addressAccessor == null) throw new IllegalArgumentException("addressAccessor must be set");
         if (persistPathAccessor == null) throw new IllegalArgumentException("persistPathAccessor must be set");
+        if (backupAction == null) throw new IllegalArgumentException("backupAction must be set");
         this.handle = handle;
         this.stopAction = stopAction;
         this.freeAction = freeAction;
         this.portAccessor = portAccessor;
         this.addressAccessor = addressAccessor;
         this.persistPathAccessor = persistPathAccessor;
+        this.backupAction = backupAction;
         this.closed = new AtomicBoolean(false);
     }
 
@@ -116,8 +121,9 @@ public final class ServerSession implements AutoCloseable {
         throw new UnsupportedOperationException("pruneAllWAL will be wired in Phase 10");
     }
 
-    public BackupManifest backup(BackupOptions options) {
+    public BackupResult<ServerSession> backup(BackupOptions options) {
         ensureOpen();
-        throw new UnsupportedOperationException("backup will be wired in Phase 9");
+        if (options == null) throw new IllegalArgumentException("options is required");
+        return backupAction.apply(options);
     }
 }

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/BackupExecutorTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/BackupExecutorTest.java
@@ -1,0 +1,159 @@
+package tech.amikos.chroma.local.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class BackupExecutorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void executeCopiesFilesAndWritesManifest() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        Files.writeString(source.resolve("sentinel.txt"), "test-data");
+
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString())
+                .includeMetadata(true)
+                .build();
+
+        AtomicBoolean closed = new AtomicBoolean(false);
+        BackupResult<String> result = BackupExecutor.execute(
+                "embedded", source.toString(), options,
+                () -> closed.set(true),
+                () -> "new-session");
+
+        assertTrue(closed.get());
+        assertNotNull(result.manifest());
+        assertEquals("new-session", result.session());
+
+        Path sentinelCopy = dest.resolve("persist").resolve("sentinel.txt");
+        assertTrue(Files.exists(sentinelCopy));
+        assertEquals("test-data", Files.readString(sentinelCopy));
+
+        Path manifestFile = dest.resolve("backup_manifest.json");
+        assertTrue(Files.exists(manifestFile));
+
+        BackupManifest manifest = JsonUtil.fromJson(Files.readString(manifestFile), BackupManifest.class);
+        assertNotNull(manifest);
+        assertEquals("v1", manifest.schemaVersion());
+        assertEquals("embedded", manifest.mode());
+        assertTrue(manifest.fileCount() >= 1);
+        assertTrue(manifest.totalBytes() > 0);
+        assertEquals(1, manifest.files().size());
+    }
+
+    @Test
+    void executeLeaveClosedReturnsNullSession() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString())
+                .leaveClosed(true)
+                .build();
+
+        BackupResult<String> result = BackupExecutor.execute(
+                "embedded", source.toString(), options,
+                () -> {},
+                () -> "should-not-be-called");
+
+        assertNotNull(result.manifest());
+        assertNull(result.session());
+    }
+
+    @Test
+    void rejectsLeaveStoppedForEmbeddedMode() {
+        Path source = tempDir.resolve("source");
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString())
+                .leaveStopped(true)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () ->
+                BackupExecutor.execute("embedded", source.toString(), options, () -> {}, () -> "x"));
+    }
+
+    @Test
+    void rejectsLeaveClosedForServerMode() {
+        Path source = tempDir.resolve("source");
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString())
+                .leaveClosed(true)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () ->
+                BackupExecutor.execute("server", source.toString(), options, () -> {}, () -> "x"));
+    }
+
+    @Test
+    void rejectsDestinationInsideSource() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        Path dest = source.resolve("backups").resolve("today");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
+
+        assertThrows(IllegalArgumentException.class, () ->
+                BackupExecutor.execute("embedded", source.toString(), options, () -> {}, () -> "x"));
+    }
+
+    @Test
+    void rejectsNonEmptyDestination() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        Path dest = tempDir.resolve("backup");
+        Files.createDirectories(dest);
+        Files.writeString(dest.resolve("existing.txt"), "data");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
+
+        assertThrows(IllegalArgumentException.class, () ->
+                BackupExecutor.execute("embedded", source.toString(), options, () -> {}, () -> "x"));
+    }
+
+    @Test
+    void handlesNonExistentSourcePath() {
+        Path source = tempDir.resolve("does-not-exist");
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
+
+        BackupResult<String> result = BackupExecutor.execute(
+                "embedded", source.toString(), options,
+                () -> {},
+                () -> "new-session");
+
+        assertNotNull(result.manifest());
+        assertEquals(0, result.manifest().fileCount());
+        assertEquals(0, result.manifest().totalBytes());
+    }
+
+    @Test
+    void extractPersistPathFromTopLevel() {
+        String yaml = "persist_path: /tmp/chroma\nsqlite_filename: chroma.sqlite3\n";
+        assertEquals("/tmp/chroma", BackupExecutor.extractPersistPath(yaml));
+    }
+
+    @Test
+    void extractPersistPathFromNestedChromaKey() {
+        String yaml = "chroma:\n  persist_path: /data/chroma\n";
+        assertEquals("/data/chroma", BackupExecutor.extractPersistPath(yaml));
+    }
+}

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/BackupExecutorTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/BackupExecutorTest.java
@@ -110,8 +110,9 @@ class BackupExecutorTest {
 
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
 
-        assertThrows(IllegalArgumentException.class, () ->
+        BackupExecutor.PreValidationFailure ex = assertThrows(BackupExecutor.PreValidationFailure.class, () ->
                 BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options, () -> {}, () -> "x"));
+        assertTrue(ex.getCause() instanceof IllegalArgumentException);
     }
 
     @Test
@@ -124,8 +125,9 @@ class BackupExecutorTest {
 
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
 
-        assertThrows(IllegalArgumentException.class, () ->
+        BackupExecutor.PreValidationFailure ex = assertThrows(BackupExecutor.PreValidationFailure.class, () ->
                 BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options, () -> {}, () -> "x"));
+        assertTrue(ex.getCause() instanceof IllegalArgumentException);
     }
 
     @Test
@@ -137,8 +139,9 @@ class BackupExecutorTest {
 
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
 
-        assertThrows(IllegalArgumentException.class, () ->
+        BackupExecutor.PreValidationFailure ex = assertThrows(BackupExecutor.PreValidationFailure.class, () ->
                 BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options, () -> {}, () -> "x"));
+        assertTrue(ex.getCause() instanceof IllegalArgumentException);
     }
 
     @Test

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/BackupExecutorTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/BackupExecutorTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 class BackupExecutorTest {
 
+    private static final String TEST_VERSION = "test-1.0";
+
     @TempDir
     Path tempDir;
 
@@ -34,7 +36,7 @@ class BackupExecutorTest {
 
         AtomicBoolean closed = new AtomicBoolean(false);
         BackupResult<String> result = BackupExecutor.execute(
-                BackupMode.EMBEDDED, source.toString(), options,
+                BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options,
                 () -> closed.set(true),
                 () -> "new-session");
 
@@ -53,6 +55,7 @@ class BackupExecutorTest {
         assertNotNull(manifest);
         assertEquals("v1", manifest.schemaVersion());
         assertEquals("embedded", manifest.mode());
+        assertEquals(TEST_VERSION, manifest.wrapperVersion());
         assertTrue(manifest.fileCount() >= 1);
         assertTrue(manifest.totalBytes() > 0);
         assertEquals(1, manifest.files().size());
@@ -70,7 +73,7 @@ class BackupExecutorTest {
                 .build();
 
         BackupResult<String> result = BackupExecutor.execute(
-                BackupMode.EMBEDDED, source.toString(), options,
+                BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options,
                 () -> {},
                 () -> "should-not-be-called");
 
@@ -90,7 +93,7 @@ class BackupExecutorTest {
                 .build();
 
         BackupResult<String> result = BackupExecutor.execute(
-                BackupMode.SERVER, source.toString(), options,
+                BackupMode.SERVER, source.toString(), TEST_VERSION, options,
                 () -> {},
                 () -> "should-not-be-called");
 
@@ -108,7 +111,7 @@ class BackupExecutorTest {
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
 
         assertThrows(IllegalArgumentException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options, () -> {}, () -> "x"));
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options, () -> {}, () -> "x"));
     }
 
     @Test
@@ -122,7 +125,7 @@ class BackupExecutorTest {
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
 
         assertThrows(IllegalArgumentException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options, () -> {}, () -> "x"));
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options, () -> {}, () -> "x"));
     }
 
     @Test
@@ -135,7 +138,7 @@ class BackupExecutorTest {
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
 
         assertThrows(IllegalArgumentException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options, () -> {}, () -> "x"));
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options, () -> {}, () -> "x"));
     }
 
     @Test
@@ -147,7 +150,7 @@ class BackupExecutorTest {
 
         AtomicBoolean restarted = new AtomicBoolean(false);
         ChromaException ex = assertThrows(ChromaException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options,
                         () -> {},
                         () -> { restarted.set(true); return "new-session"; }));
 
@@ -168,7 +171,7 @@ class BackupExecutorTest {
                 .build();
 
         BackupResult<String> result = BackupExecutor.execute(
-                BackupMode.EMBEDDED, source.toString(), options,
+                BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options,
                 () -> {},
                 () -> "session");
 
@@ -192,7 +195,7 @@ class BackupExecutorTest {
                 .build();
 
         BackupResult<String> result = BackupExecutor.execute(
-                BackupMode.EMBEDDED, source.toString(), options,
+                BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options,
                 () -> {},
                 () -> "session");
 
@@ -216,7 +219,7 @@ class BackupExecutorTest {
                 .build();
 
         BackupResult<String> result = BackupExecutor.execute(
-                BackupMode.EMBEDDED, source.toString(), options,
+                BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options,
                 () -> {},
                 () -> "session");
 
@@ -241,7 +244,7 @@ class BackupExecutorTest {
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
 
         assertThrows(ChromaException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options,
                         () -> {},
                         () -> "session"));
     }
@@ -254,7 +257,7 @@ class BackupExecutorTest {
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
 
         assertThrows(RuntimeException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options,
                         () -> { throw new RuntimeException("close failed"); },
                         () -> "session"));
 
@@ -275,12 +278,14 @@ class BackupExecutorTest {
 
         AtomicBoolean restarted = new AtomicBoolean(false);
         ChromaException ex = assertThrows(ChromaException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options,
                         () -> {},
                         () -> { restarted.set(true); return "restarted"; }));
 
         assertTrue(restarted.get(), "restart must be attempted even after copy failure");
         assertTrue(ex.getCause() instanceof IOException, "original IOException must be preserved as cause");
+        assertTrue(!Files.exists(dest) || isEmptyDir(dest),
+                "partial backup must be cleaned up when restart succeeds after copy failure");
     }
 
     @Test
@@ -296,7 +301,7 @@ class BackupExecutorTest {
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
 
         ChromaException ex = assertThrows(ChromaException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options,
                         () -> {},
                         () -> { throw new RuntimeException("restart failed"); }));
 
@@ -319,7 +324,7 @@ class BackupExecutorTest {
                 .build();
 
         ChromaException ex = assertThrows(ChromaException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options,
                         () -> {},
                         () -> "should-not-be-called"));
 
@@ -341,7 +346,7 @@ class BackupExecutorTest {
                 .build();
 
         assertThrows(RuntimeException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options,
                         () -> {},
                         () -> "should-not-be-called"));
 
@@ -349,43 +354,50 @@ class BackupExecutorTest {
                 "partial backup must be cleaned up in leave-inactive path");
     }
 
-    // --- Fix #11: null argument rejection ---
+    // --- null argument rejection ---
 
     @Test
     void executeRejectsNullMode() {
         BackupOptions options = new BackupOptions.Builder("/tmp/dest").build();
         assertThrows(NullPointerException.class, () ->
-                BackupExecutor.execute(null, "/src", options, () -> {}, () -> "s"));
+                BackupExecutor.execute(null, "/src", TEST_VERSION, options, () -> {}, () -> "s"));
     }
 
     @Test
     void executeRejectsNullPersistPath() {
         BackupOptions options = new BackupOptions.Builder("/tmp/dest").build();
         assertThrows(NullPointerException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, null, options, () -> {}, () -> "s"));
+                BackupExecutor.execute(BackupMode.EMBEDDED, null, TEST_VERSION, options, () -> {}, () -> "s"));
+    }
+
+    @Test
+    void executeRejectsNullWrapperVersion() {
+        BackupOptions options = new BackupOptions.Builder("/tmp/dest").build();
+        assertThrows(NullPointerException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, "/src", null, options, () -> {}, () -> "s"));
     }
 
     @Test
     void executeRejectsNullOptions() {
         assertThrows(NullPointerException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, "/src", null, () -> {}, () -> "s"));
+                BackupExecutor.execute(BackupMode.EMBEDDED, "/src", TEST_VERSION, null, () -> {}, () -> "s"));
     }
 
     @Test
     void executeRejectsNullCloseAction() {
         BackupOptions options = new BackupOptions.Builder("/tmp/dest").build();
         assertThrows(NullPointerException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, "/src", options, null, () -> "s"));
+                BackupExecutor.execute(BackupMode.EMBEDDED, "/src", TEST_VERSION, options, null, () -> "s"));
     }
 
     @Test
     void executeRejectsNullRestartAction() {
         BackupOptions options = new BackupOptions.Builder("/tmp/dest").build();
         assertThrows(NullPointerException.class, () ->
-                BackupExecutor.execute(BackupMode.EMBEDDED, "/src", options, () -> {}, null));
+                BackupExecutor.execute(BackupMode.EMBEDDED, "/src", TEST_VERSION, options, () -> {}, null));
     }
 
-    // --- Fix #14: manifest list immutability ---
+    // --- manifest list immutability ---
 
     @Test
     void manifestSourcePathsIsImmutable() throws IOException {
@@ -395,7 +407,7 @@ class BackupExecutorTest {
 
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
         BackupResult<String> result = BackupExecutor.execute(
-                BackupMode.EMBEDDED, source.toString(), options, () -> {}, () -> "s");
+                BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options, () -> {}, () -> "s");
 
         assertThrows(UnsupportedOperationException.class, () ->
                 result.manifest().sourcePaths().add("evil"));
@@ -412,54 +424,10 @@ class BackupExecutorTest {
                 .includeMetadata(true)
                 .build();
         BackupResult<String> result = BackupExecutor.execute(
-                BackupMode.EMBEDDED, source.toString(), options, () -> {}, () -> "s");
+                BackupMode.EMBEDDED, source.toString(), TEST_VERSION, options, () -> {}, () -> "s");
 
         assertThrows(UnsupportedOperationException.class, () ->
                 result.manifest().files().add(new BackupFileMetadata("x", 0, "0644", "abc", "now")));
-    }
-
-    // --- extractPersistPath ---
-
-    @Test
-    void extractPersistPathFromTopLevel() {
-        String yaml = "persist_path: /tmp/chroma\nsqlite_filename: chroma.sqlite3\n";
-        assertEquals("/tmp/chroma", BackupExecutor.extractPersistPath(yaml));
-    }
-
-    @Test
-    void extractPersistPathFromNestedChromaKey() {
-        String yaml = "chroma:\n  persist_path: /data/chroma\n";
-        assertEquals("/data/chroma", BackupExecutor.extractPersistPath(yaml));
-    }
-
-    @Test
-    void extractPersistPathTopLevelTakesPrecedence() {
-        String yaml = "persist_path: /top\nchroma:\n  persist_path: /nested\n";
-        assertEquals("/top", BackupExecutor.extractPersistPath(yaml));
-    }
-
-    @Test
-    void extractPersistPathThrowsForMissingKey() {
-        assertThrows(IllegalArgumentException.class, () ->
-                BackupExecutor.extractPersistPath("some_other_key: value\n"));
-    }
-
-    @Test
-    void extractPersistPathThrowsForInvalidYaml() {
-        assertThrows(IllegalArgumentException.class, () ->
-                BackupExecutor.extractPersistPath("just-a-string"));
-    }
-
-    @Test
-    void extractPersistPathThrowsForEmptyYaml() {
-        assertThrows(IllegalArgumentException.class, () ->
-                BackupExecutor.extractPersistPath(""));
-    }
-
-    @Test
-    void extractPersistPathThrowsForMalformedYaml() {
-        assertThrows(IllegalArgumentException.class, () ->
-                BackupExecutor.extractPersistPath("{: invalid yaml ["));
     }
 
     private static boolean isEmptyDir(Path dir) {

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/BackupExecutorTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/BackupExecutorTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -32,7 +34,7 @@ class BackupExecutorTest {
 
         AtomicBoolean closed = new AtomicBoolean(false);
         BackupResult<String> result = BackupExecutor.execute(
-                "embedded", source.toString(), options,
+                BackupMode.EMBEDDED, source.toString(), options,
                 () -> closed.set(true),
                 () -> "new-session");
 
@@ -47,7 +49,7 @@ class BackupExecutorTest {
         Path manifestFile = dest.resolve("backup_manifest.json");
         assertTrue(Files.exists(manifestFile));
 
-        BackupManifest manifest = JsonUtil.fromJson(Files.readString(manifestFile), BackupManifest.class);
+        BackupManifest manifest = result.manifest();
         assertNotNull(manifest);
         assertEquals("v1", manifest.schemaVersion());
         assertEquals("embedded", manifest.mode());
@@ -57,18 +59,18 @@ class BackupExecutorTest {
     }
 
     @Test
-    void executeLeaveClosedReturnsNullSession() throws IOException {
+    void leaveInactiveEmbeddedReturnsNullSession() throws IOException {
         Path source = tempDir.resolve("source");
         Files.createDirectories(source);
 
         Path dest = tempDir.resolve("backup");
 
         BackupOptions options = new BackupOptions.Builder(dest.toString())
-                .leaveClosed(true)
+                .leaveInactive(true)
                 .build();
 
         BackupResult<String> result = BackupExecutor.execute(
-                "embedded", source.toString(), options,
+                BackupMode.EMBEDDED, source.toString(), options,
                 () -> {},
                 () -> "should-not-be-called");
 
@@ -77,29 +79,24 @@ class BackupExecutorTest {
     }
 
     @Test
-    void rejectsLeaveStoppedForEmbeddedMode() {
+    void leaveInactiveServerReturnsNullSession() throws IOException {
         Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+
         Path dest = tempDir.resolve("backup");
 
         BackupOptions options = new BackupOptions.Builder(dest.toString())
-                .leaveStopped(true)
+                .leaveInactive(true)
                 .build();
 
-        assertThrows(IllegalArgumentException.class, () ->
-                BackupExecutor.execute("embedded", source.toString(), options, () -> {}, () -> "x"));
-    }
+        BackupResult<String> result = BackupExecutor.execute(
+                BackupMode.SERVER, source.toString(), options,
+                () -> {},
+                () -> "should-not-be-called");
 
-    @Test
-    void rejectsLeaveClosedForServerMode() {
-        Path source = tempDir.resolve("source");
-        Path dest = tempDir.resolve("backup");
-
-        BackupOptions options = new BackupOptions.Builder(dest.toString())
-                .leaveClosed(true)
-                .build();
-
-        assertThrows(IllegalArgumentException.class, () ->
-                BackupExecutor.execute("server", source.toString(), options, () -> {}, () -> "x"));
+        assertNotNull(result.manifest());
+        assertNull(result.session());
+        assertEquals("server", result.manifest().mode());
     }
 
     @Test
@@ -111,7 +108,7 @@ class BackupExecutorTest {
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
 
         assertThrows(IllegalArgumentException.class, () ->
-                BackupExecutor.execute("embedded", source.toString(), options, () -> {}, () -> "x"));
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options, () -> {}, () -> "x"));
     }
 
     @Test
@@ -125,25 +122,303 @@ class BackupExecutorTest {
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
 
         assertThrows(IllegalArgumentException.class, () ->
-                BackupExecutor.execute("embedded", source.toString(), options, () -> {}, () -> "x"));
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options, () -> {}, () -> "x"));
     }
 
     @Test
-    void handlesNonExistentSourcePath() {
+    void rejectsDestinationThatIsAFile() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        Path dest = tempDir.resolve("backup-file");
+        Files.writeString(dest, "i am a file");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
+
+        assertThrows(IllegalArgumentException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options, () -> {}, () -> "x"));
+    }
+
+    @Test
+    void rejectsNonExistentSourcePath() {
         Path source = tempDir.resolve("does-not-exist");
         Path dest = tempDir.resolve("backup");
 
         BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
 
-        BackupResult<String> result = BackupExecutor.execute(
-                "embedded", source.toString(), options,
-                () -> {},
-                () -> "new-session");
+        AtomicBoolean restarted = new AtomicBoolean(false);
+        ChromaException ex = assertThrows(ChromaException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                        () -> {},
+                        () -> { restarted.set(true); return "new-session"; }));
 
-        assertNotNull(result.manifest());
-        assertEquals(0, result.manifest().fileCount());
-        assertEquals(0, result.manifest().totalBytes());
+        assertTrue(ex.getMessage().contains("backup source path does not exist"));
+        assertTrue(restarted.get(), "restart must be attempted even after source-not-found error");
     }
+
+    @Test
+    void includeMetadataFalseProducesEmptyFilesList() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        Files.writeString(source.resolve("data.txt"), "content");
+
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString())
+                .includeMetadata(false)
+                .build();
+
+        BackupResult<String> result = BackupExecutor.execute(
+                BackupMode.EMBEDDED, source.toString(), options,
+                () -> {},
+                () -> "session");
+
+        BackupManifest manifest = result.manifest();
+        assertTrue(manifest.fileCount() >= 1);
+        assertTrue(manifest.totalBytes() > 0);
+        assertTrue(manifest.files().isEmpty());
+    }
+
+    @Test
+    void sha256HashIsCorrect() throws Exception {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        String content = "hello-sha256-test";
+        Files.writeString(source.resolve("hashme.txt"), content);
+
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString())
+                .includeMetadata(true)
+                .build();
+
+        BackupResult<String> result = BackupExecutor.execute(
+                BackupMode.EMBEDDED, source.toString(), options,
+                () -> {},
+                () -> "session");
+
+        BackupFileMetadata meta = result.manifest().files().get(0);
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        String expected = HexFormat.of().formatHex(digest.digest(content.getBytes()));
+        assertEquals(expected, meta.sha256());
+    }
+
+    @Test
+    void nestedDirectoryStructureIsCopied() throws IOException {
+        Path source = tempDir.resolve("source");
+        Path subdir = source.resolve("subdir");
+        Files.createDirectories(subdir);
+        Files.writeString(subdir.resolve("nested.txt"), "nested-content");
+
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString())
+                .includeMetadata(true)
+                .build();
+
+        BackupResult<String> result = BackupExecutor.execute(
+                BackupMode.EMBEDDED, source.toString(), options,
+                () -> {},
+                () -> "session");
+
+        Path copiedNested = dest.resolve("persist").resolve("subdir").resolve("nested.txt");
+        assertTrue(Files.exists(copiedNested));
+        assertEquals("nested-content", Files.readString(copiedNested));
+
+        BackupFileMetadata meta = result.manifest().files().get(0);
+        assertEquals("subdir/nested.txt", meta.path());
+    }
+
+    @Test
+    void symlinkInSourceIsRejected() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        Path target = tempDir.resolve("target-file");
+        Files.writeString(target, "real-content");
+        Files.createSymbolicLink(source.resolve("link.txt"), target);
+
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
+
+        assertThrows(ChromaException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                        () -> {},
+                        () -> "session"));
+    }
+
+    @Test
+    void closeActionFailureCleansUpDestination() {
+        Path source = tempDir.resolve("source");
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
+
+        assertThrows(RuntimeException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                        () -> { throw new RuntimeException("close failed"); },
+                        () -> "session"));
+
+        assertTrue(!Files.exists(dest) || isEmptyDir(dest));
+    }
+
+    @Test
+    void restartIsAttemptedOnCopyFailure() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        Path target = tempDir.resolve("target-file");
+        Files.writeString(target, "real-content");
+        Files.createSymbolicLink(source.resolve("link.txt"), target);
+
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
+
+        AtomicBoolean restarted = new AtomicBoolean(false);
+        ChromaException ex = assertThrows(ChromaException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                        () -> {},
+                        () -> { restarted.set(true); return "restarted"; }));
+
+        assertTrue(restarted.get(), "restart must be attempted even after copy failure");
+        assertTrue(ex.getCause() instanceof IOException, "original IOException must be preserved as cause");
+    }
+
+    @Test
+    void copyFailureWithRestartFailureIncludesBothErrors() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        Path target = tempDir.resolve("target-file");
+        Files.writeString(target, "real-content");
+        Files.createSymbolicLink(source.resolve("link.txt"), target);
+
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
+
+        ChromaException ex = assertThrows(ChromaException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                        () -> {},
+                        () -> { throw new RuntimeException("restart failed"); }));
+
+        assertTrue(ex.getMessage().contains("restart also failed"));
+        assertTrue(ex.getSuppressed().length >= 1, "backup error must be suppressed on restart failure");
+    }
+
+    @Test
+    void copyFailureInLeaveInactivePathThrows() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        Path target = tempDir.resolve("target-file");
+        Files.writeString(target, "real-content");
+        Files.createSymbolicLink(source.resolve("link.txt"), target);
+
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString())
+                .leaveInactive(true)
+                .build();
+
+        ChromaException ex = assertThrows(ChromaException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                        () -> {},
+                        () -> "should-not-be-called"));
+
+        assertNotNull(ex.getCause());
+    }
+
+    @Test
+    void copyFailureInLeaveInactivePathCleansUpDestination() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        Path target = tempDir.resolve("target-file");
+        Files.writeString(target, "real-content");
+        Files.createSymbolicLink(source.resolve("link.txt"), target);
+
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString())
+                .leaveInactive(true)
+                .build();
+
+        assertThrows(RuntimeException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, source.toString(), options,
+                        () -> {},
+                        () -> "should-not-be-called"));
+
+        assertTrue(!Files.exists(dest) || isEmptyDir(dest),
+                "partial backup must be cleaned up in leave-inactive path");
+    }
+
+    // --- Fix #11: null argument rejection ---
+
+    @Test
+    void executeRejectsNullMode() {
+        BackupOptions options = new BackupOptions.Builder("/tmp/dest").build();
+        assertThrows(NullPointerException.class, () ->
+                BackupExecutor.execute(null, "/src", options, () -> {}, () -> "s"));
+    }
+
+    @Test
+    void executeRejectsNullPersistPath() {
+        BackupOptions options = new BackupOptions.Builder("/tmp/dest").build();
+        assertThrows(NullPointerException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, null, options, () -> {}, () -> "s"));
+    }
+
+    @Test
+    void executeRejectsNullOptions() {
+        assertThrows(NullPointerException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, "/src", null, () -> {}, () -> "s"));
+    }
+
+    @Test
+    void executeRejectsNullCloseAction() {
+        BackupOptions options = new BackupOptions.Builder("/tmp/dest").build();
+        assertThrows(NullPointerException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, "/src", options, null, () -> "s"));
+    }
+
+    @Test
+    void executeRejectsNullRestartAction() {
+        BackupOptions options = new BackupOptions.Builder("/tmp/dest").build();
+        assertThrows(NullPointerException.class, () ->
+                BackupExecutor.execute(BackupMode.EMBEDDED, "/src", options, () -> {}, null));
+    }
+
+    // --- Fix #14: manifest list immutability ---
+
+    @Test
+    void manifestSourcePathsIsImmutable() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString()).build();
+        BackupResult<String> result = BackupExecutor.execute(
+                BackupMode.EMBEDDED, source.toString(), options, () -> {}, () -> "s");
+
+        assertThrows(UnsupportedOperationException.class, () ->
+                result.manifest().sourcePaths().add("evil"));
+    }
+
+    @Test
+    void manifestFilesIsImmutable() throws IOException {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source);
+        Files.writeString(source.resolve("f.txt"), "data");
+        Path dest = tempDir.resolve("backup");
+
+        BackupOptions options = new BackupOptions.Builder(dest.toString())
+                .includeMetadata(true)
+                .build();
+        BackupResult<String> result = BackupExecutor.execute(
+                BackupMode.EMBEDDED, source.toString(), options, () -> {}, () -> "s");
+
+        assertThrows(UnsupportedOperationException.class, () ->
+                result.manifest().files().add(new BackupFileMetadata("x", 0, "0644", "abc", "now")));
+    }
+
+    // --- extractPersistPath ---
 
     @Test
     void extractPersistPathFromTopLevel() {
@@ -155,5 +430,43 @@ class BackupExecutorTest {
     void extractPersistPathFromNestedChromaKey() {
         String yaml = "chroma:\n  persist_path: /data/chroma\n";
         assertEquals("/data/chroma", BackupExecutor.extractPersistPath(yaml));
+    }
+
+    @Test
+    void extractPersistPathTopLevelTakesPrecedence() {
+        String yaml = "persist_path: /top\nchroma:\n  persist_path: /nested\n";
+        assertEquals("/top", BackupExecutor.extractPersistPath(yaml));
+    }
+
+    @Test
+    void extractPersistPathThrowsForMissingKey() {
+        assertThrows(IllegalArgumentException.class, () ->
+                BackupExecutor.extractPersistPath("some_other_key: value\n"));
+    }
+
+    @Test
+    void extractPersistPathThrowsForInvalidYaml() {
+        assertThrows(IllegalArgumentException.class, () ->
+                BackupExecutor.extractPersistPath("just-a-string"));
+    }
+
+    @Test
+    void extractPersistPathThrowsForEmptyYaml() {
+        assertThrows(IllegalArgumentException.class, () ->
+                BackupExecutor.extractPersistPath(""));
+    }
+
+    @Test
+    void extractPersistPathThrowsForMalformedYaml() {
+        assertThrows(IllegalArgumentException.class, () ->
+                BackupExecutor.extractPersistPath("{: invalid yaml ["));
+    }
+
+    private static boolean isEmptyDir(Path dir) {
+        try (var entries = Files.list(dir)) {
+            return entries.findFirst().isEmpty();
+        } catch (IOException e) {
+            return true;
+        }
     }
 }

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/BackupFileMetadataTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/BackupFileMetadataTest.java
@@ -1,6 +1,5 @@
 package tech.amikos.chroma.local.core;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -32,8 +31,8 @@ class BackupFileMetadataTest {
     }
 
     @Test
-    void allowsNullMode() {
-        assertDoesNotThrow(() ->
+    void rejectsNullMode() {
+        assertThrows(NullPointerException.class, () ->
                 new BackupFileMetadata("f.txt", 0, null, "abc", "now"));
     }
 }

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/BackupFileMetadataTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/BackupFileMetadataTest.java
@@ -1,0 +1,39 @@
+package tech.amikos.chroma.local.core;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class BackupFileMetadataTest {
+
+    @Test
+    void rejectsNullPath() {
+        assertThrows(NullPointerException.class, () ->
+                new BackupFileMetadata(null, 0, "0644", "abc", "now"));
+    }
+
+    @Test
+    void rejectsNullSha256() {
+        assertThrows(NullPointerException.class, () ->
+                new BackupFileMetadata("f.txt", 0, "0644", null, "now"));
+    }
+
+    @Test
+    void rejectsNullModifiedAt() {
+        assertThrows(NullPointerException.class, () ->
+                new BackupFileMetadata("f.txt", 0, "0644", "abc", null));
+    }
+
+    @Test
+    void rejectsNegativeSizeBytes() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new BackupFileMetadata("f.txt", -1, "0644", "abc", "now"));
+    }
+
+    @Test
+    void allowsNullMode() {
+        assertDoesNotThrow(() ->
+                new BackupFileMetadata("f.txt", 0, null, "abc", "now"));
+    }
+}

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/BackupOptionsTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/BackupOptionsTest.java
@@ -7,17 +7,6 @@ import org.junit.jupiter.api.Test;
 class BackupOptionsTest {
 
     @Test
-    void toJsonProducesExpectedKeys() {
-        BackupOptions opts = new BackupOptions.Builder("/tmp/backup")
-                .includeMetadata(true)
-                .build();
-        String json = opts.toJson();
-        assertTrue(json.contains("\"destination_path\""));
-        assertTrue(json.contains("\"/tmp/backup\""));
-        assertTrue(json.contains("\"include_metadata\""));
-    }
-
-    @Test
     void builderRejectsBlankDestination() {
         assertThrows(IllegalArgumentException.class, () ->
                 new BackupOptions.Builder("  ").build());
@@ -33,12 +22,10 @@ class BackupOptionsTest {
     void builderAcceptsFlags() {
         BackupOptions opts = new BackupOptions.Builder("/tmp/backup")
                 .includeMetadata(true)
-                .leaveStopped(true)
-                .leaveClosed(true)
+                .leaveInactive(true)
                 .build();
         assertTrue(opts.includeMetadata());
-        assertTrue(opts.leaveStopped());
-        assertTrue(opts.leaveClosed());
+        assertTrue(opts.leaveInactive());
     }
 
     @Test
@@ -46,7 +33,6 @@ class BackupOptionsTest {
         BackupOptions opts = new BackupOptions.Builder("/tmp/backup").build();
         assertEquals("/tmp/backup", opts.destinationPath());
         assertFalse(opts.includeMetadata());
-        assertFalse(opts.leaveStopped());
-        assertFalse(opts.leaveClosed());
+        assertFalse(opts.leaveInactive());
     }
 }

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/BackupResultTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/BackupResultTest.java
@@ -1,0 +1,32 @@
+package tech.amikos.chroma.local.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class BackupResultTest {
+
+    @Test
+    void manifestAndSessionAccessors() {
+        BackupManifest manifest = new BackupManifest();
+        String session = "test-session";
+        BackupResult<String> result = new BackupResult<>(manifest, session);
+        assertEquals(manifest, result.manifest());
+        assertEquals("test-session", result.session());
+    }
+
+    @Test
+    void rejectsNullManifest() {
+        assertThrows(NullPointerException.class, () -> new BackupResult<>(null, "session"));
+    }
+
+    @Test
+    void allowsNullSession() {
+        BackupManifest manifest = new BackupManifest();
+        BackupResult<String> result = new BackupResult<>(manifest, null);
+        assertEquals(manifest, result.manifest());
+        assertNull(result.session());
+    }
+}

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/BackupResultTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/BackupResultTest.java
@@ -4,13 +4,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class BackupResultTest {
 
+    private static BackupManifest testManifest() {
+        return new BackupManifest("v1", "embedded", "now", "java",
+                List.of("/src"), "/dst", "/dst/persist", "/dst/manifest.json",
+                false, 0, 0, null);
+    }
+
     @Test
     void manifestAndSessionAccessors() {
-        BackupManifest manifest = new BackupManifest();
+        BackupManifest manifest = testManifest();
         String session = "test-session";
         BackupResult<String> result = new BackupResult<>(manifest, session);
         assertEquals(manifest, result.manifest());
@@ -24,7 +31,7 @@ class BackupResultTest {
 
     @Test
     void allowsNullSession() {
-        BackupManifest manifest = new BackupManifest();
+        BackupManifest manifest = testManifest();
         BackupResult<String> result = new BackupResult<>(manifest, null);
         assertEquals(manifest, result.manifest());
         assertNull(result.session());

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/EmbeddedSessionTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/EmbeddedSessionTest.java
@@ -284,6 +284,26 @@ class EmbeddedSessionTest {
     }
 
     @Test
+    void backupPreValidationFailureLeavesSessionOpen() {
+        AtomicInteger closeCalls = new AtomicInteger();
+        EmbeddedSession session = new EmbeddedSession(42L, ignored -> closeCalls.incrementAndGet(),
+                STUB_REBUILD, STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
+                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL,
+                opts -> { throw new BackupExecutor.PreValidationFailure(
+                        new IllegalArgumentException("dest inside source")); });
+
+        BackupOptions options = new BackupOptions.Builder("/tmp/backup").build();
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> session.backup(options));
+        assertEquals("dest inside source", ex.getMessage());
+
+        assertEquals(42L, session.handle(), "session must remain open after pre-validation failure");
+
+        session.close();
+        assertEquals(1, closeCalls.get(), "closeAction must run on explicit close");
+    }
+
+    @Test
     void pruneCollectionWalConvenienceOverloadDelegates() {
         AtomicLong capturedHandle = new AtomicLong();
         AtomicReference<String> capturedJson = new AtomicReference<>();

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/EmbeddedSessionTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/EmbeddedSessionTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.LongConsumer;
 import org.junit.jupiter.api.Test;
 
@@ -24,11 +25,13 @@ class EmbeddedSessionTest {
             (h, json) -> { throw new UnsupportedOperationException("stub"); };
     private static final BiFunction<Long, String, WALPruneResult> STUB_PRUNE_WAL_ALL =
             (h, json) -> { throw new UnsupportedOperationException("stub"); };
+    private static final Function<BackupOptions, BackupResult<EmbeddedSession>> STUB_BACKUP =
+            opts -> { throw new UnsupportedOperationException("stub"); };
 
     private static EmbeddedSession create(long handle, LongConsumer closeAction) {
         return new EmbeddedSession(handle, closeAction,
                 STUB_REBUILD, STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
-                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL);
+                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL, STUB_BACKUP);
     }
 
     // --- Constructor null-rejection tests ---
@@ -47,35 +50,42 @@ class EmbeddedSessionTest {
     void constructorRejectsNullRebuildAction() {
         assertThrows(IllegalArgumentException.class, () -> new EmbeddedSession(42L, ignored -> {},
                 null, STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
-                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL));
+                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL, STUB_BACKUP));
     }
 
     @Test
     void constructorRejectsNullCompactCollectionAction() {
         assertThrows(IllegalArgumentException.class, () -> new EmbeddedSession(42L, ignored -> {},
                 STUB_REBUILD, null, STUB_COMPACT_ALL,
-                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL));
+                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL, STUB_BACKUP));
     }
 
     @Test
     void constructorRejectsNullCompactAllAction() {
         assertThrows(IllegalArgumentException.class, () -> new EmbeddedSession(42L, ignored -> {},
                 STUB_REBUILD, STUB_COMPACT_COLLECTION, null,
-                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL));
+                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL, STUB_BACKUP));
     }
 
     @Test
     void constructorRejectsNullPruneWalCollectionAction() {
         assertThrows(IllegalArgumentException.class, () -> new EmbeddedSession(42L, ignored -> {},
                 STUB_REBUILD, STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
-                null, STUB_PRUNE_WAL_ALL));
+                null, STUB_PRUNE_WAL_ALL, STUB_BACKUP));
     }
 
     @Test
     void constructorRejectsNullPruneWalAllAction() {
         assertThrows(IllegalArgumentException.class, () -> new EmbeddedSession(42L, ignored -> {},
                 STUB_REBUILD, STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
-                STUB_PRUNE_WAL_COLLECTION, null));
+                STUB_PRUNE_WAL_COLLECTION, null, STUB_BACKUP));
+    }
+
+    @Test
+    void constructorRejectsNullBackupAction() {
+        assertThrows(IllegalArgumentException.class, () -> new EmbeddedSession(42L, ignored -> {},
+                STUB_REBUILD, STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
+                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL, null));
     }
 
     // --- Close lifecycle tests ---
@@ -150,6 +160,20 @@ class EmbeddedSessionTest {
         assertThrows(IllegalArgumentException.class, () -> session.pruneAllWAL(null));
     }
 
+    @Test
+    void backupRejectsNullOptions() {
+        EmbeddedSession session = create(42L, ignored -> {});
+        assertThrows(IllegalArgumentException.class, () -> session.backup(null));
+    }
+
+    @Test
+    void backupThrowsAfterClose() {
+        EmbeddedSession session = create(42L, ignored -> {});
+        session.close();
+        BackupOptions opts = new BackupOptions.Builder("/tmp/dest").build();
+        assertThrows(IllegalStateException.class, () -> session.backup(opts));
+    }
+
     // --- Convenience overload delegation tests ---
 
     @Test
@@ -161,7 +185,7 @@ class EmbeddedSessionTest {
         EmbeddedSession session = new EmbeddedSession(42L, ignored -> {},
                 (h, json) -> { capturedHandle.set(h); capturedJson.set(json); return fakeResult; },
                 STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
-                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL);
+                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL, STUB_BACKUP);
 
         RebuildCollectionResult result = session.rebuildCollection("myCollection");
 
@@ -181,7 +205,7 @@ class EmbeddedSessionTest {
                 STUB_REBUILD,
                 (h, json) -> { capturedHandle.set(h); capturedJson.set(json); return fakeResult; },
                 STUB_COMPACT_ALL,
-                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL);
+                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL, STUB_BACKUP);
 
         CompactionResult result = session.compactCollection("myCollection");
 
@@ -200,7 +224,7 @@ class EmbeddedSessionTest {
         EmbeddedSession session = new EmbeddedSession(42L, ignored -> {},
                 STUB_REBUILD, STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
                 (h, json) -> { capturedHandle.set(h); capturedJson.set(json); return fakeResult; },
-                STUB_PRUNE_WAL_ALL);
+                STUB_PRUNE_WAL_ALL, STUB_BACKUP);
 
         WALPruneResult result = session.pruneCollectionWAL("myCollection");
 

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/EmbeddedSessionTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/EmbeddedSessionTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -33,8 +34,6 @@ class EmbeddedSessionTest {
                 STUB_REBUILD, STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
                 STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL, STUB_BACKUP);
     }
-
-    // --- Constructor null-rejection tests ---
 
     @Test
     void constructorRejectsZeroHandle() {
@@ -88,8 +87,6 @@ class EmbeddedSessionTest {
                 STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL, null));
     }
 
-    // --- Close lifecycle tests ---
-
     @Test
     void closeInvokesActionOnce() {
         AtomicInteger closeCalls = new AtomicInteger();
@@ -112,7 +109,7 @@ class EmbeddedSessionTest {
         assertThrows(RuntimeException.class, session::close);
         assertThrows(IllegalStateException.class, session::handle, "handle poisoned after failed close");
         session.close();
-        assertEquals(1, closeCalls.get(), "closeAction must not be retried — native handle is in unknown state");
+        assertEquals(1, closeCalls.get(), "closeAction must not be retried");
     }
 
     @Test
@@ -127,8 +124,6 @@ class EmbeddedSessionTest {
         session.close();
         assertThrows(IllegalStateException.class, session::handle);
     }
-
-    // --- Input validation tests ---
 
     @Test
     void rebuildCollectionRejectsNullOptions() {
@@ -174,8 +169,6 @@ class EmbeddedSessionTest {
         assertThrows(IllegalStateException.class, () -> session.backup(opts));
     }
 
-    // --- Convenience overload delegation tests ---
-
     @Test
     void rebuildCollectionConvenienceOverloadDelegates() {
         AtomicLong capturedHandle = new AtomicLong();
@@ -213,6 +206,81 @@ class EmbeddedSessionTest {
         assertEquals(42L, capturedHandle.get());
         assertNotNull(capturedJson.get());
         assertTrue(capturedJson.get().contains("myCollection"));
+    }
+
+    @Test
+    void backupDelegatesAndInvalidatesSession() {
+        BackupManifest manifest = new BackupManifest("v1", "embedded", "now", "java",
+                java.util.List.of("/src"), "/dst", "/dst/persist", "/dst/manifest.json",
+                false, 0, 0, null);
+        BackupResult<EmbeddedSession> fakeResult = new BackupResult<>(manifest, null);
+        AtomicReference<BackupOptions> capturedOpts = new AtomicReference<>();
+
+        EmbeddedSession session = new EmbeddedSession(42L, ignored -> {},
+                STUB_REBUILD, STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
+                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL,
+                opts -> { capturedOpts.set(opts); return fakeResult; });
+
+        BackupOptions options = new BackupOptions.Builder("/tmp/backup").build();
+        BackupResult<EmbeddedSession> result = session.backup(options);
+
+        assertEquals(fakeResult, result);
+        assertEquals(options, capturedOpts.get());
+        assertThrows(IllegalStateException.class, session::handle,
+                "session must be invalidated after backup");
+    }
+
+    @Test
+    void backupSetsClosedAfterActionNotBefore() {
+        AtomicBoolean wasOpenDuringAction = new AtomicBoolean(false);
+        BackupManifest manifest = new BackupManifest("v1", "embedded", "now", "java",
+                java.util.List.of("/src"), "/dst", "/dst/persist", "/dst/manifest.json",
+                false, 0, 0, null);
+
+        EmbeddedSession session = new EmbeddedSession(42L, ignored -> {},
+                STUB_REBUILD, STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
+                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL,
+                opts -> {
+                    wasOpenDuringAction.set(true);
+                    return new BackupResult<>(manifest, null);
+                });
+
+        session.backup(new BackupOptions.Builder("/tmp/backup").build());
+        assertTrue(wasOpenDuringAction.get(), "backupAction must execute before session is marked closed");
+        assertThrows(IllegalStateException.class, session::handle,
+                "session must be closed after backup completes");
+    }
+
+    @Test
+    void closeAfterBackupIsNoOp() {
+        BackupManifest manifest = new BackupManifest("v1", "embedded", "now", "java",
+                java.util.List.of("/src"), "/dst", "/dst/persist", "/dst/manifest.json",
+                false, 0, 0, null);
+        AtomicInteger closeCalls = new AtomicInteger();
+
+        EmbeddedSession session = new EmbeddedSession(42L, ignored -> closeCalls.incrementAndGet(),
+                STUB_REBUILD, STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
+                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL,
+                opts -> new BackupResult<>(manifest, null));
+
+        session.backup(new BackupOptions.Builder("/tmp/backup").build());
+        session.close();
+        assertEquals(0, closeCalls.get(), "closeAction must not be called after backup invalidated the session");
+    }
+
+    @Test
+    void backupFailureStillInvalidatesSession() {
+        EmbeddedSession session = new EmbeddedSession(42L, ignored -> {},
+                STUB_REBUILD, STUB_COMPACT_COLLECTION, STUB_COMPACT_ALL,
+                STUB_PRUNE_WAL_COLLECTION, STUB_PRUNE_WAL_ALL,
+                opts -> { throw new RuntimeException("backup failed"); });
+
+        BackupOptions options = new BackupOptions.Builder("/tmp/backup").build();
+        assertThrows(RuntimeException.class, () -> session.backup(options));
+
+        assertThrows(IllegalStateException.class, session::handle,
+                "session must be invalidated even when backup fails");
+        session.close();
     }
 
     @Test

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/ServerSessionTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/ServerSessionTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
@@ -263,6 +264,69 @@ class ServerSessionTest {
         session.close();
         BackupOptions opts = new BackupOptions.Builder("/tmp/dest").build();
         assertThrows(IllegalStateException.class, () -> session.backup(opts));
+    }
+
+    @Test
+    void backupDelegatesAndInvalidatesSession() {
+        BackupManifest manifest = new BackupManifest("v1", "server", "now", "java",
+                java.util.List.of("/src"), "/dst", "/dst/persist", "/dst/manifest.json",
+                false, 0, 0, null);
+        BackupResult<ServerSession> fakeResult = new BackupResult<>(manifest, null);
+        AtomicReference<BackupOptions> capturedOpts = new AtomicReference<>();
+
+        ServerSession session = new ServerSession(
+                42L,
+                h -> {}, h -> {},
+                h -> 8000, h -> "host", h -> "/path",
+                opts -> { capturedOpts.set(opts); return fakeResult; }
+        );
+
+        BackupOptions options = new BackupOptions.Builder("/tmp/backup").build();
+        BackupResult<ServerSession> result = session.backup(options);
+
+        assertEquals(fakeResult, result);
+        assertEquals(options, capturedOpts.get());
+        assertThrows(IllegalStateException.class, session::port,
+                "session must be invalidated after backup");
+    }
+
+    @Test
+    void closeAfterBackupIsNoOp() {
+        BackupManifest manifest = new BackupManifest("v1", "server", "now", "java",
+                java.util.List.of("/src"), "/dst", "/dst/persist", "/dst/manifest.json",
+                false, 0, 0, null);
+        AtomicInteger stopCalls = new AtomicInteger();
+        AtomicInteger freeCalls = new AtomicInteger();
+
+        ServerSession session = new ServerSession(
+                42L,
+                h -> stopCalls.incrementAndGet(),
+                h -> freeCalls.incrementAndGet(),
+                h -> 8000, h -> "host", h -> "/path",
+                opts -> new BackupResult<>(manifest, null)
+        );
+
+        session.backup(new BackupOptions.Builder("/tmp/backup").build());
+        session.close();
+        assertEquals(0, stopCalls.get(), "stopAction must not be called after backup invalidated the session");
+        assertEquals(0, freeCalls.get(), "freeAction must not be called after backup invalidated the session");
+    }
+
+    @Test
+    void backupFailureStillInvalidatesSession() {
+        ServerSession session = new ServerSession(
+                42L,
+                h -> {}, h -> {},
+                h -> 8000, h -> "host", h -> "/path",
+                opts -> { throw new RuntimeException("backup failed"); }
+        );
+
+        BackupOptions options = new BackupOptions.Builder("/tmp/backup").build();
+        assertThrows(RuntimeException.class, () -> session.backup(options));
+
+        assertThrows(IllegalStateException.class, session::port,
+                "session must be invalidated even when backup fails");
+        session.close();
     }
 
     @Test

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/ServerSessionTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/ServerSessionTest.java
@@ -5,9 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
 class ServerSessionTest {
+
+    private static final Function<BackupOptions, BackupResult<ServerSession>> STUB_BACKUP =
+            opts -> { throw new UnsupportedOperationException("stub"); };
 
     private ServerSession createSession(long handle) {
         return new ServerSession(
@@ -16,44 +20,51 @@ class ServerSessionTest {
                 h -> {},
                 h -> 8000,
                 h -> "localhost",
-                h -> "/data"
+                h -> "/data",
+                STUB_BACKUP
         );
     }
 
     @Test
     void constructorRejectsZeroHandle() {
         assertThrows(IllegalArgumentException.class,
-                () -> new ServerSession(0L, h -> {}, h -> {}, h -> 0, h -> "", h -> ""));
+                () -> new ServerSession(0L, h -> {}, h -> {}, h -> 0, h -> "", h -> "", STUB_BACKUP));
     }
 
     @Test
     void constructorRejectsNullStopAction() {
         assertThrows(IllegalArgumentException.class,
-                () -> new ServerSession(1L, null, h -> {}, h -> 0, h -> "", h -> ""));
+                () -> new ServerSession(1L, null, h -> {}, h -> 0, h -> "", h -> "", STUB_BACKUP));
     }
 
     @Test
     void constructorRejectsNullFreeAction() {
         assertThrows(IllegalArgumentException.class,
-                () -> new ServerSession(1L, h -> {}, null, h -> 0, h -> "", h -> ""));
+                () -> new ServerSession(1L, h -> {}, null, h -> 0, h -> "", h -> "", STUB_BACKUP));
     }
 
     @Test
     void constructorRejectsNullPortAccessor() {
         assertThrows(IllegalArgumentException.class,
-                () -> new ServerSession(1L, h -> {}, h -> {}, null, h -> "", h -> ""));
+                () -> new ServerSession(1L, h -> {}, h -> {}, null, h -> "", h -> "", STUB_BACKUP));
     }
 
     @Test
     void constructorRejectsNullAddressAccessor() {
         assertThrows(IllegalArgumentException.class,
-                () -> new ServerSession(1L, h -> {}, h -> {}, h -> 0, null, h -> ""));
+                () -> new ServerSession(1L, h -> {}, h -> {}, h -> 0, null, h -> "", STUB_BACKUP));
     }
 
     @Test
     void constructorRejectsNullPersistPathAccessor() {
         assertThrows(IllegalArgumentException.class,
-                () -> new ServerSession(1L, h -> {}, h -> {}, h -> 0, h -> "", null));
+                () -> new ServerSession(1L, h -> {}, h -> {}, h -> 0, h -> "", null, STUB_BACKUP));
+    }
+
+    @Test
+    void constructorRejectsNullBackupAction() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ServerSession(1L, h -> {}, h -> {}, h -> 0, h -> "", h -> "", null));
     }
 
     @Test
@@ -76,7 +87,8 @@ class ServerSessionTest {
                 99L,
                 h -> {}, h -> {},
                 h -> { receivedHandle.set(h); return 9090; },
-                h -> "host", h -> "/path"
+                h -> "host", h -> "/path",
+                STUB_BACKUP
         );
         assertEquals(9090, session.port());
         assertEquals(99L, receivedHandle.get());
@@ -90,7 +102,8 @@ class ServerSessionTest {
                 h -> {}, h -> {},
                 h -> 8000,
                 h -> { receivedHandle.set(h); return "0.0.0.0"; },
-                h -> "/path"
+                h -> "/path",
+                STUB_BACKUP
         );
         assertEquals("0.0.0.0", session.address());
         assertEquals(88L, receivedHandle.get());
@@ -103,7 +116,8 @@ class ServerSessionTest {
                 77L,
                 h -> {}, h -> {},
                 h -> 8000, h -> "host",
-                h -> { receivedHandle.set(h); return "/my/data"; }
+                h -> { receivedHandle.set(h); return "/my/data"; },
+                STUB_BACKUP
         );
         assertEquals("/my/data", session.persistPath());
         assertEquals(77L, receivedHandle.get());
@@ -116,7 +130,8 @@ class ServerSessionTest {
                 h -> {}, h -> {},
                 h -> 8080,
                 h -> "127.0.0.1",
-                h -> "/data"
+                h -> "/data",
+                STUB_BACKUP
         );
         assertEquals("http://127.0.0.1:8080", session.url());
     }
@@ -129,7 +144,8 @@ class ServerSessionTest {
                 1L,
                 h -> stopCalls.incrementAndGet(),
                 h -> freeCalls.incrementAndGet(),
-                h -> 8000, h -> "host", h -> "/path"
+                h -> 8000, h -> "host", h -> "/path",
+                STUB_BACKUP
         );
         session.close();
         assertEquals(1, stopCalls.get());
@@ -144,7 +160,8 @@ class ServerSessionTest {
                 1L,
                 h -> stopCalls.incrementAndGet(),
                 h -> freeCalls.incrementAndGet(),
-                h -> 8000, h -> "host", h -> "/path"
+                h -> 8000, h -> "host", h -> "/path",
+                STUB_BACKUP
         );
         session.close();
         session.close();
@@ -160,7 +177,8 @@ class ServerSessionTest {
                 1L,
                 h -> { throw new RuntimeException("stop failed"); },
                 h -> freeCalls.incrementAndGet(),
-                h -> 8000, h -> "host", h -> "/path"
+                h -> 8000, h -> "host", h -> "/path",
+                STUB_BACKUP
         );
         assertThrows(RuntimeException.class, session::close);
         assertEquals(1, freeCalls.get(), "freeAction must run even if stopAction throws");
@@ -173,7 +191,8 @@ class ServerSessionTest {
                 1L,
                 h -> { stopCalls.incrementAndGet(); throw new RuntimeException("stop failed"); },
                 h -> {},
-                h -> 8000, h -> "host", h -> "/path"
+                h -> 8000, h -> "host", h -> "/path",
+                STUB_BACKUP
         );
         assertThrows(RuntimeException.class, session::close);
         assertThrows(IllegalStateException.class, session::port);
@@ -188,7 +207,8 @@ class ServerSessionTest {
                 1L,
                 h -> { throw new RuntimeException("stop failed"); },
                 h -> { throw new RuntimeException("free failed"); },
-                h -> 8000, h -> "host", h -> "/path"
+                h -> 8000, h -> "host", h -> "/path",
+                STUB_BACKUP
         );
         RuntimeException ex = assertThrows(RuntimeException.class, session::close);
         assertEquals("stop failed", ex.getMessage(), "stop exception propagates as primary");
@@ -232,10 +252,17 @@ class ServerSessionTest {
     }
 
     @Test
-    void backup_throwsUnsupportedOperationException() {
+    void backupRejectsNullOptions() {
         ServerSession session = createSession(1L);
-        assertThrows(UnsupportedOperationException.class,
-                () -> session.backup(null));
+        assertThrows(IllegalArgumentException.class, () -> session.backup(null));
+    }
+
+    @Test
+    void backupThrowsAfterClose() {
+        ServerSession session = createSession(1L);
+        session.close();
+        BackupOptions opts = new BackupOptions.Builder("/tmp/dest").build();
+        assertThrows(IllegalStateException.class, () -> session.backup(opts));
     }
 
     @Test
@@ -252,7 +279,7 @@ class ServerSessionTest {
                 () -> session.pruneCollectionWAL(WALPruneOptions.defaults("coll")));
         assertThrows(IllegalStateException.class,
                 () -> session.pruneAllWAL(null));
-        assertThrows(IllegalStateException.class,
-                () -> session.backup(null));
+        BackupOptions opts = new BackupOptions.Builder("/tmp/dest").build();
+        assertThrows(IllegalStateException.class, () -> session.backup(opts));
     }
 }

--- a/java/core/src/test/java/tech/amikos/chroma/local/core/ServerSessionTest.java
+++ b/java/core/src/test/java/tech/amikos/chroma/local/core/ServerSessionTest.java
@@ -330,6 +330,31 @@ class ServerSessionTest {
     }
 
     @Test
+    void backupPreValidationFailureLeavesSessionOpen() {
+        AtomicInteger stopCalls = new AtomicInteger();
+        AtomicInteger freeCalls = new AtomicInteger();
+        ServerSession session = new ServerSession(
+                42L,
+                h -> stopCalls.incrementAndGet(),
+                h -> freeCalls.incrementAndGet(),
+                h -> 8000, h -> "host", h -> "/path",
+                opts -> { throw new BackupExecutor.PreValidationFailure(
+                        new IllegalArgumentException("dest inside source")); }
+        );
+
+        BackupOptions options = new BackupOptions.Builder("/tmp/backup").build();
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> session.backup(options));
+        assertEquals("dest inside source", ex.getMessage());
+
+        assertEquals(8000, session.port(), "session must remain open after pre-validation failure");
+
+        session.close();
+        assertEquals(1, stopCalls.get(), "stopAction must run on explicit close");
+        assertEquals(1, freeCalls.get(), "freeAction must run on explicit close");
+    }
+
+    @Test
     void maintenanceMethods_throwIllegalStateException_afterClose() {
         ServerSession session = createSession(1L);
         session.close();

--- a/java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java
+++ b/java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java
@@ -6,6 +6,7 @@ import com.sun.jna.Pointer;
 import java.nio.file.Path;
 import tech.amikos.chroma.local.core.AbstractChromaRuntime;
 import tech.amikos.chroma.local.core.BackupExecutor;
+import tech.amikos.chroma.local.core.BackupMode;
 import tech.amikos.chroma.local.core.BackupOptions;
 import tech.amikos.chroma.local.core.BackupResult;
 import tech.amikos.chroma.local.core.ChromaException;
@@ -103,7 +104,13 @@ public final class JnaChromaRuntime extends AbstractChromaRuntime {
     protected EmbeddedSession doStartEmbedded(String configYaml) {
         long handle = callFfiHandle(
                 () -> Pointer.nativeValue(bindings.chroma_embedded_start_from_string(configYaml)));
-        String persistPath = BackupExecutor.extractPersistPath(configYaml);
+        String persistPath;
+        try {
+            persistPath = BackupExecutor.extractPersistPath(configYaml);
+        } catch (RuntimeException e) {
+            embeddedFree(handle);
+            throw e;
+        }
         final String savedYaml = configYaml;
         return new EmbeddedSession(
                 handle,
@@ -123,7 +130,7 @@ public final class JnaChromaRuntime extends AbstractChromaRuntime {
                 (h, json) -> callFfiJson(
                         () -> Pointer.nativeValue(bindings.chroma_embedded_prune_wal_all(new Pointer(h), json)),
                         WALPruneResult.class),
-                opts -> BackupExecutor.execute("embedded", persistPath, opts,
+                opts -> BackupExecutor.execute(BackupMode.EMBEDDED, persistPath, opts,
                         () -> embeddedFree(handle), () -> doStartEmbedded(savedYaml)));
     }
 
@@ -140,7 +147,7 @@ public final class JnaChromaRuntime extends AbstractChromaRuntime {
                 this::serverPort,
                 this::serverAddress,
                 this::serverPersistPath,
-                opts -> BackupExecutor.execute("server", persistPath, opts,
+                opts -> BackupExecutor.execute(BackupMode.SERVER, persistPath, opts,
                         () -> { serverStop(handle); serverFree(handle); },
                         () -> doStartServer(savedYaml)));
     }

--- a/java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java
+++ b/java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java
@@ -5,6 +5,9 @@ import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import java.nio.file.Path;
 import tech.amikos.chroma.local.core.AbstractChromaRuntime;
+import tech.amikos.chroma.local.core.BackupExecutor;
+import tech.amikos.chroma.local.core.BackupOptions;
+import tech.amikos.chroma.local.core.BackupResult;
 import tech.amikos.chroma.local.core.ChromaException;
 import tech.amikos.chroma.local.core.CompactionResult;
 import tech.amikos.chroma.local.core.EmbeddedSession;
@@ -100,6 +103,8 @@ public final class JnaChromaRuntime extends AbstractChromaRuntime {
     protected EmbeddedSession doStartEmbedded(String configYaml) {
         long handle = callFfiHandle(
                 () -> Pointer.nativeValue(bindings.chroma_embedded_start_from_string(configYaml)));
+        String persistPath = BackupExecutor.extractPersistPath(configYaml);
+        final String savedYaml = configYaml;
         return new EmbeddedSession(
                 handle,
                 this::embeddedFree,
@@ -117,20 +122,27 @@ public final class JnaChromaRuntime extends AbstractChromaRuntime {
                         WALPruneResult.class),
                 (h, json) -> callFfiJson(
                         () -> Pointer.nativeValue(bindings.chroma_embedded_prune_wal_all(new Pointer(h), json)),
-                        WALPruneResult.class));
+                        WALPruneResult.class),
+                opts -> BackupExecutor.execute("embedded", persistPath, opts,
+                        () -> embeddedFree(handle), () -> doStartEmbedded(savedYaml)));
     }
 
     @Override
     protected ServerSession doStartServer(String configYaml) {
         long handle = callFfiHandle(
                 () -> Pointer.nativeValue(bindings.chroma_server_start_from_string(configYaml)));
+        String persistPath = serverPersistPath(handle);
+        final String savedYaml = configYaml;
         return new ServerSession(
                 handle,
                 this::serverStop,
                 this::serverFree,
                 this::serverPort,
                 this::serverAddress,
-                this::serverPersistPath);
+                this::serverPersistPath,
+                opts -> BackupExecutor.execute("server", persistPath, opts,
+                        () -> { serverStop(handle); serverFree(handle); },
+                        () -> doStartServer(savedYaml)));
     }
 
     private void serverStop(long handle) {

--- a/java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java
+++ b/java/jna/src/main/java/tech/amikos/chroma/local/jna/JnaChromaRuntime.java
@@ -7,8 +7,6 @@ import java.nio.file.Path;
 import tech.amikos.chroma.local.core.AbstractChromaRuntime;
 import tech.amikos.chroma.local.core.BackupExecutor;
 import tech.amikos.chroma.local.core.BackupMode;
-import tech.amikos.chroma.local.core.BackupOptions;
-import tech.amikos.chroma.local.core.BackupResult;
 import tech.amikos.chroma.local.core.ChromaException;
 import tech.amikos.chroma.local.core.CompactionResult;
 import tech.amikos.chroma.local.core.EmbeddedSession;
@@ -49,6 +47,8 @@ public final class JnaChromaRuntime extends AbstractChromaRuntime {
         int chroma_server_port(Pointer handle);
 
         Pointer chroma_server_address(Pointer handle);
+
+        Pointer chroma_embedded_persist_path(Pointer handle);
 
         Pointer chroma_server_persist_path(Pointer handle);
     }
@@ -104,14 +104,8 @@ public final class JnaChromaRuntime extends AbstractChromaRuntime {
     protected EmbeddedSession doStartEmbedded(String configYaml) {
         long handle = callFfiHandle(
                 () -> Pointer.nativeValue(bindings.chroma_embedded_start_from_string(configYaml)));
-        String persistPath;
-        try {
-            persistPath = BackupExecutor.extractPersistPath(configYaml);
-        } catch (RuntimeException e) {
-            embeddedFree(handle);
-            throw e;
-        }
-        final String savedYaml = configYaml;
+        String persistPath = embeddedPersistPath(handle);
+        String version = doVersion();
         return new EmbeddedSession(
                 handle,
                 this::embeddedFree,
@@ -130,8 +124,8 @@ public final class JnaChromaRuntime extends AbstractChromaRuntime {
                 (h, json) -> callFfiJson(
                         () -> Pointer.nativeValue(bindings.chroma_embedded_prune_wal_all(new Pointer(h), json)),
                         WALPruneResult.class),
-                opts -> BackupExecutor.execute(BackupMode.EMBEDDED, persistPath, opts,
-                        () -> embeddedFree(handle), () -> doStartEmbedded(savedYaml)));
+                opts -> BackupExecutor.execute(BackupMode.EMBEDDED, persistPath, version, opts,
+                        () -> embeddedFree(handle), () -> doStartEmbedded(configYaml)));
     }
 
     @Override
@@ -139,7 +133,7 @@ public final class JnaChromaRuntime extends AbstractChromaRuntime {
         long handle = callFfiHandle(
                 () -> Pointer.nativeValue(bindings.chroma_server_start_from_string(configYaml)));
         String persistPath = serverPersistPath(handle);
-        final String savedYaml = configYaml;
+        String version = doVersion();
         return new ServerSession(
                 handle,
                 this::serverStop,
@@ -147,9 +141,9 @@ public final class JnaChromaRuntime extends AbstractChromaRuntime {
                 this::serverPort,
                 this::serverAddress,
                 this::serverPersistPath,
-                opts -> BackupExecutor.execute(BackupMode.SERVER, persistPath, opts,
+                opts -> BackupExecutor.execute(BackupMode.SERVER, persistPath, version, opts,
                         () -> { serverStop(handle); serverFree(handle); },
-                        () -> doStartServer(savedYaml)));
+                        () -> doStartServer(configYaml)));
     }
 
     private void serverStop(long handle) {
@@ -168,6 +162,11 @@ public final class JnaChromaRuntime extends AbstractChromaRuntime {
     private String serverAddress(long handle) {
         return callFfiBorrowedString(
                 () -> Pointer.nativeValue(bindings.chroma_server_address(new Pointer(handle))));
+    }
+
+    private String embeddedPersistPath(long handle) {
+        return callFfiBorrowedString(
+                () -> Pointer.nativeValue(bindings.chroma_embedded_persist_path(new Pointer(handle))));
     }
 
     private String serverPersistPath(long handle) {

--- a/java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaEmbeddedBackupTest.java
+++ b/java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaEmbeddedBackupTest.java
@@ -55,13 +55,13 @@ class JnaEmbeddedBackupTest {
     }
 
     @Test
-    void embeddedBackupWithLeaveClosed(
+    void embeddedBackupWithLeaveInactive(
             @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
             @TempDir Path backupDir) throws Exception {
         String libPath = System.getenv("CHROMA_LIB_PATH");
         Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
 
-        Files.writeString(persistDir.resolve("sentinel.txt"), "leave-closed-test");
+        Files.writeString(persistDir.resolve("sentinel.txt"), "leave-inactive-test");
 
         String yaml = new EmbeddedConfigBuilder()
                 .persistPath(persistDir.toAbsolutePath().toString())
@@ -73,34 +73,11 @@ class JnaEmbeddedBackupTest {
         try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath)) {
             EmbeddedSession session = runtime.startEmbedded(yaml);
             BackupResult<EmbeddedSession> result = session.backup(
-                    new BackupOptions.Builder(dest.toString()).leaveClosed(true).build());
+                    new BackupOptions.Builder(dest.toString()).leaveInactive(true).build());
 
             assertNull(result.session());
             assertNotNull(result.manifest());
             assertTrue(Files.exists(dest.resolve("backup_manifest.json")));
-        }
-    }
-
-    @Test
-    void embeddedBackupRejectsLeaveStopped(
-            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
-            @TempDir Path backupDir) {
-        String libPath = System.getenv("CHROMA_LIB_PATH");
-        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
-
-        String yaml = new EmbeddedConfigBuilder()
-                .persistPath(persistDir.toAbsolutePath().toString())
-                .allowReset(true)
-                .build();
-
-        Path dest = backupDir.resolve("output");
-
-        try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath);
-             EmbeddedSession session = runtime.startEmbedded(yaml)) {
-            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                    () -> session.backup(
-                            new BackupOptions.Builder(dest.toString()).leaveStopped(true).build()));
-            assertTrue(ex.getMessage().contains("leaveStopped"));
         }
     }
 

--- a/java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaEmbeddedBackupTest.java
+++ b/java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaEmbeddedBackupTest.java
@@ -1,0 +1,146 @@
+package tech.amikos.chroma.local.jna;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+import tech.amikos.chroma.local.core.BackupOptions;
+import tech.amikos.chroma.local.core.BackupResult;
+import tech.amikos.chroma.local.core.EmbeddedConfigBuilder;
+import tech.amikos.chroma.local.core.EmbeddedSession;
+
+class JnaEmbeddedBackupTest {
+
+    @Test
+    void embeddedBackupCreatesDirectoryWithManifest(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        Files.writeString(persistDir.resolve("sentinel.txt"), "backup-test-data");
+
+        String yaml = new EmbeddedConfigBuilder()
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath)) {
+            EmbeddedSession session = runtime.startEmbedded(yaml);
+            BackupResult<EmbeddedSession> result = session.backup(
+                    new BackupOptions.Builder(dest.toString()).includeMetadata(true).build());
+
+            assertNotNull(result.manifest());
+            assertEquals("v1", result.manifest().schemaVersion());
+            assertEquals("embedded", result.manifest().mode());
+            assertTrue(result.manifest().fileCount() >= 1);
+            assertTrue(Files.exists(dest.resolve("persist").resolve("sentinel.txt")));
+            assertEquals("backup-test-data",
+                    Files.readString(dest.resolve("persist").resolve("sentinel.txt")));
+            assertTrue(Files.exists(dest.resolve("backup_manifest.json")));
+            assertNotNull(result.session());
+
+            result.session().close();
+        }
+    }
+
+    @Test
+    void embeddedBackupWithLeaveClosed(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        Files.writeString(persistDir.resolve("sentinel.txt"), "leave-closed-test");
+
+        String yaml = new EmbeddedConfigBuilder()
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath)) {
+            EmbeddedSession session = runtime.startEmbedded(yaml);
+            BackupResult<EmbeddedSession> result = session.backup(
+                    new BackupOptions.Builder(dest.toString()).leaveClosed(true).build());
+
+            assertNull(result.session());
+            assertNotNull(result.manifest());
+            assertTrue(Files.exists(dest.resolve("backup_manifest.json")));
+        }
+    }
+
+    @Test
+    void embeddedBackupRejectsLeaveStopped(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        String yaml = new EmbeddedConfigBuilder()
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath);
+             EmbeddedSession session = runtime.startEmbedded(yaml)) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> session.backup(
+                            new BackupOptions.Builder(dest.toString()).leaveStopped(true).build()));
+            assertTrue(ex.getMessage().contains("leaveStopped"));
+        }
+    }
+
+    @Test
+    void embeddedBackupRejectsNullOptions(@TempDir(cleanup = CleanupMode.NEVER) Path persistDir) {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        String yaml = new EmbeddedConfigBuilder()
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath);
+             EmbeddedSession session = runtime.startEmbedded(yaml)) {
+            assertThrows(IllegalArgumentException.class, () -> session.backup(null));
+        }
+    }
+
+    @Test
+    void embeddedBackupThrowsAfterClose(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        String yaml = new EmbeddedConfigBuilder()
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath)) {
+            EmbeddedSession session = runtime.startEmbedded(yaml);
+            session.close();
+
+            assertThrows(IllegalStateException.class,
+                    () -> session.backup(
+                            new BackupOptions.Builder(dest.toString()).build()));
+        }
+    }
+}

--- a/java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaServerBackupTest.java
+++ b/java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaServerBackupTest.java
@@ -1,0 +1,173 @@
+package tech.amikos.chroma.local.jna;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+import tech.amikos.chroma.local.core.BackupOptions;
+import tech.amikos.chroma.local.core.BackupResult;
+import tech.amikos.chroma.local.core.ServerConfigBuilder;
+import tech.amikos.chroma.local.core.ServerSession;
+
+class JnaServerBackupTest {
+
+    @Test
+    void serverBackupCreatesDirectoryWithManifest(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        Files.writeString(persistDir.resolve("sentinel.txt"), "server-backup-test");
+
+        int port = findFreePort();
+        String yaml = new ServerConfigBuilder()
+                .port(port)
+                .listenAddress("127.0.0.1")
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath)) {
+            ServerSession session = runtime.startServer(yaml);
+            BackupResult<ServerSession> result = session.backup(
+                    new BackupOptions.Builder(dest.toString()).includeMetadata(true).build());
+
+            assertNotNull(result.manifest());
+            assertEquals("v1", result.manifest().schemaVersion());
+            assertEquals("server", result.manifest().mode());
+            assertTrue(result.manifest().fileCount() >= 1);
+            assertTrue(Files.exists(dest.resolve("persist").resolve("sentinel.txt")));
+            assertTrue(Files.exists(dest.resolve("backup_manifest.json")));
+            assertNotNull(result.session());
+            assertTrue(result.session().port() > 0);
+
+            result.session().close();
+        }
+    }
+
+    @Test
+    void serverBackupWithLeaveStopped(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        Files.writeString(persistDir.resolve("sentinel.txt"), "leave-stopped-test");
+
+        int port = findFreePort();
+        String yaml = new ServerConfigBuilder()
+                .port(port)
+                .listenAddress("127.0.0.1")
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath)) {
+            ServerSession session = runtime.startServer(yaml);
+            BackupResult<ServerSession> result = session.backup(
+                    new BackupOptions.Builder(dest.toString()).leaveStopped(true).build());
+
+            assertNull(result.session());
+            assertNotNull(result.manifest());
+            assertTrue(Files.exists(dest.resolve("backup_manifest.json")));
+        }
+    }
+
+    @Test
+    void serverBackupRejectsLeaveClosed(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        int port = findFreePort();
+        String yaml = new ServerConfigBuilder()
+                .port(port)
+                .listenAddress("127.0.0.1")
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath)) {
+            ServerSession session = runtime.startServer(yaml);
+            try {
+                IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                        () -> session.backup(
+                                new BackupOptions.Builder(dest.toString()).leaveClosed(true).build()));
+                assertTrue(ex.getMessage().contains("leaveClosed"));
+            } finally {
+                session.close();
+            }
+        }
+    }
+
+    @Test
+    void serverBackupRejectsNullOptions(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        int port = findFreePort();
+        String yaml = new ServerConfigBuilder()
+                .port(port)
+                .listenAddress("127.0.0.1")
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath);
+             ServerSession session = runtime.startServer(yaml)) {
+            assertThrows(IllegalArgumentException.class, () -> session.backup(null));
+        }
+    }
+
+    @Test
+    void serverBackupThrowsAfterClose(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        int port = findFreePort();
+        String yaml = new ServerConfigBuilder()
+                .port(port)
+                .listenAddress("127.0.0.1")
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath)) {
+            ServerSession session = runtime.startServer(yaml);
+            session.close();
+
+            assertThrows(IllegalStateException.class,
+                    () -> session.backup(
+                            new BackupOptions.Builder(dest.toString()).build()));
+        }
+    }
+
+    private static int findFreePort() throws IOException {
+        try (ServerSocket s = new ServerSocket(0)) {
+            return s.getLocalPort();
+        }
+    }
+}

--- a/java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaServerBackupTest.java
+++ b/java/jna/src/test/java/tech/amikos/chroma/local/jna/JnaServerBackupTest.java
@@ -59,13 +59,13 @@ class JnaServerBackupTest {
     }
 
     @Test
-    void serverBackupWithLeaveStopped(
+    void serverBackupWithLeaveInactive(
             @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
             @TempDir Path backupDir) throws Exception {
         String libPath = System.getenv("CHROMA_LIB_PATH");
         Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
 
-        Files.writeString(persistDir.resolve("sentinel.txt"), "leave-stopped-test");
+        Files.writeString(persistDir.resolve("sentinel.txt"), "leave-inactive-test");
 
         int port = findFreePort();
         String yaml = new ServerConfigBuilder()
@@ -80,41 +80,11 @@ class JnaServerBackupTest {
         try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath)) {
             ServerSession session = runtime.startServer(yaml);
             BackupResult<ServerSession> result = session.backup(
-                    new BackupOptions.Builder(dest.toString()).leaveStopped(true).build());
+                    new BackupOptions.Builder(dest.toString()).leaveInactive(true).build());
 
             assertNull(result.session());
             assertNotNull(result.manifest());
             assertTrue(Files.exists(dest.resolve("backup_manifest.json")));
-        }
-    }
-
-    @Test
-    void serverBackupRejectsLeaveClosed(
-            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
-            @TempDir Path backupDir) throws Exception {
-        String libPath = System.getenv("CHROMA_LIB_PATH");
-        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
-
-        int port = findFreePort();
-        String yaml = new ServerConfigBuilder()
-                .port(port)
-                .listenAddress("127.0.0.1")
-                .persistPath(persistDir.toAbsolutePath().toString())
-                .allowReset(true)
-                .build();
-
-        Path dest = backupDir.resolve("output");
-
-        try (JnaChromaRuntime runtime = JnaChromaRuntime.init(libPath)) {
-            ServerSession session = runtime.startServer(yaml);
-            try {
-                IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                        () -> session.backup(
-                                new BackupOptions.Builder(dest.toString()).leaveClosed(true).build()));
-                assertTrue(ex.getMessage().contains("leaveClosed"));
-            } finally {
-                session.close();
-            }
         }
     }
 

--- a/java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java
+++ b/java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java
@@ -12,8 +12,6 @@ import java.util.Locale;
 import tech.amikos.chroma.local.core.AbstractChromaRuntime;
 import tech.amikos.chroma.local.core.BackupExecutor;
 import tech.amikos.chroma.local.core.BackupMode;
-import tech.amikos.chroma.local.core.BackupOptions;
-import tech.amikos.chroma.local.core.BackupResult;
 import tech.amikos.chroma.local.core.ChromaException;
 import tech.amikos.chroma.local.core.CompactionResult;
 import tech.amikos.chroma.local.core.EmbeddedSession;
@@ -38,6 +36,7 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
             MethodHandle embeddedCompactAll,
             MethodHandle embeddedPruneWalCollection,
             MethodHandle embeddedPruneWalAll,
+            MethodHandle embeddedPersistPath,
             MethodHandle serverStart,
             MethodHandle serverStop,
             MethodHandle serverFree,
@@ -92,6 +91,9 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
                     linker.downcallHandle(
                             requireSymbol(library, "chroma_embedded_prune_wal_all"),
                             FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS)),
+                    linker.downcallHandle(
+                            requireSymbol(library, "chroma_embedded_persist_path"),
+                            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS)),
                     linker.downcallHandle(
                             requireSymbol(library, "chroma_server_start_from_string"),
                             FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS)),
@@ -196,14 +198,8 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
                 throw new ChromaException("failed to start embedded runtime", t);
             }
         });
-        String persistPath;
-        try {
-            persistPath = BackupExecutor.extractPersistPath(configYaml);
-        } catch (RuntimeException e) {
-            embeddedFree(handle);
-            throw e;
-        }
-        final String savedYaml = configYaml;
+        String persistPath = embeddedPersistPath(handle);
+        String version = doVersion();
         return new EmbeddedSession(
                 handle,
                 this::embeddedFree,
@@ -262,8 +258,8 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
                         throw new ChromaException("failed to call embedded prune wal all", t);
                     }
                 }, WALPruneResult.class),
-                opts -> BackupExecutor.execute(BackupMode.EMBEDDED, persistPath, opts,
-                        () -> embeddedFree(handle), () -> doStartEmbedded(savedYaml)));
+                opts -> BackupExecutor.execute(BackupMode.EMBEDDED, persistPath, version, opts,
+                        () -> embeddedFree(handle), () -> doStartEmbedded(configYaml)));
     }
 
     @Override
@@ -279,7 +275,7 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
             }
         });
         String persistPath = serverPersistPath(handle);
-        final String savedYaml = configYaml;
+        String version = doVersion();
         return new ServerSession(
                 handle,
                 this::serverStop,
@@ -287,9 +283,9 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
                 this::serverPort,
                 this::serverAddress,
                 this::serverPersistPath,
-                opts -> BackupExecutor.execute(BackupMode.SERVER, persistPath, opts,
+                opts -> BackupExecutor.execute(BackupMode.SERVER, persistPath, version, opts,
                         () -> { serverStop(handle); serverFree(handle); },
-                        () -> doStartServer(savedYaml)));
+                        () -> doStartServer(configYaml)));
     }
 
     private void serverStop(long handleAddress) {
@@ -339,6 +335,19 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
             } catch (Throwable t) {
                 if (t instanceof Error error) throw error;
                 throw new ChromaException("failed to read server address", t);
+            }
+        });
+    }
+
+    private String embeddedPersistPath(long handleAddress) {
+        return callFfiBorrowedString(() -> {
+            try {
+                MemorySegment ptr = (MemorySegment) ffi.embeddedPersistPath().invokeExact(
+                        MemorySegment.ofAddress(handleAddress));
+                return ptr.address();
+            } catch (Throwable t) {
+                if (t instanceof Error error) throw error;
+                throw new ChromaException("failed to read embedded persist path", t);
             }
         });
     }

--- a/java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java
+++ b/java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java
@@ -10,6 +10,9 @@ import java.lang.invoke.MethodHandle;
 import java.nio.file.Path;
 import java.util.Locale;
 import tech.amikos.chroma.local.core.AbstractChromaRuntime;
+import tech.amikos.chroma.local.core.BackupExecutor;
+import tech.amikos.chroma.local.core.BackupOptions;
+import tech.amikos.chroma.local.core.BackupResult;
 import tech.amikos.chroma.local.core.ChromaException;
 import tech.amikos.chroma.local.core.CompactionResult;
 import tech.amikos.chroma.local.core.EmbeddedSession;
@@ -192,6 +195,8 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
                 throw new ChromaException("failed to start embedded runtime", t);
             }
         });
+        String persistPath = BackupExecutor.extractPersistPath(configYaml);
+        final String savedYaml = configYaml;
         return new EmbeddedSession(
                 handle,
                 this::embeddedFree,
@@ -249,7 +254,9 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
                         if (t instanceof Error error) throw error;
                         throw new ChromaException("failed to call embedded prune wal all", t);
                     }
-                }, WALPruneResult.class));
+                }, WALPruneResult.class),
+                opts -> BackupExecutor.execute("embedded", persistPath, opts,
+                        () -> embeddedFree(handle), () -> doStartEmbedded(savedYaml)));
     }
 
     @Override
@@ -264,13 +271,18 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
                 throw new ChromaException("failed to start server runtime", t);
             }
         });
+        String persistPath = serverPersistPath(handle);
+        final String savedYaml = configYaml;
         return new ServerSession(
                 handle,
                 this::serverStop,
                 this::serverFree,
                 this::serverPort,
                 this::serverAddress,
-                this::serverPersistPath);
+                this::serverPersistPath,
+                opts -> BackupExecutor.execute("server", persistPath, opts,
+                        () -> { serverStop(handle); serverFree(handle); },
+                        () -> doStartServer(savedYaml)));
     }
 
     private void serverStop(long handleAddress) {

--- a/java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java
+++ b/java/panama/src/main/java/tech/amikos/chroma/local/panama/PanamaChromaRuntime.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.util.Locale;
 import tech.amikos.chroma.local.core.AbstractChromaRuntime;
 import tech.amikos.chroma.local.core.BackupExecutor;
+import tech.amikos.chroma.local.core.BackupMode;
 import tech.amikos.chroma.local.core.BackupOptions;
 import tech.amikos.chroma.local.core.BackupResult;
 import tech.amikos.chroma.local.core.ChromaException;
@@ -195,7 +196,13 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
                 throw new ChromaException("failed to start embedded runtime", t);
             }
         });
-        String persistPath = BackupExecutor.extractPersistPath(configYaml);
+        String persistPath;
+        try {
+            persistPath = BackupExecutor.extractPersistPath(configYaml);
+        } catch (RuntimeException e) {
+            embeddedFree(handle);
+            throw e;
+        }
         final String savedYaml = configYaml;
         return new EmbeddedSession(
                 handle,
@@ -255,7 +262,7 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
                         throw new ChromaException("failed to call embedded prune wal all", t);
                     }
                 }, WALPruneResult.class),
-                opts -> BackupExecutor.execute("embedded", persistPath, opts,
+                opts -> BackupExecutor.execute(BackupMode.EMBEDDED, persistPath, opts,
                         () -> embeddedFree(handle), () -> doStartEmbedded(savedYaml)));
     }
 
@@ -280,7 +287,7 @@ public final class PanamaChromaRuntime extends AbstractChromaRuntime {
                 this::serverPort,
                 this::serverAddress,
                 this::serverPersistPath,
-                opts -> BackupExecutor.execute("server", persistPath, opts,
+                opts -> BackupExecutor.execute(BackupMode.SERVER, persistPath, opts,
                         () -> { serverStop(handle); serverFree(handle); },
                         () -> doStartServer(savedYaml)));
     }

--- a/java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaEmbeddedBackupTest.java
+++ b/java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaEmbeddedBackupTest.java
@@ -55,13 +55,13 @@ class PanamaEmbeddedBackupTest {
     }
 
     @Test
-    void embeddedBackupWithLeaveClosed(
+    void embeddedBackupWithLeaveInactive(
             @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
             @TempDir Path backupDir) throws Exception {
         String libPath = System.getenv("CHROMA_LIB_PATH");
         Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
 
-        Files.writeString(persistDir.resolve("sentinel.txt"), "leave-closed-test");
+        Files.writeString(persistDir.resolve("sentinel.txt"), "leave-inactive-test");
 
         String yaml = new EmbeddedConfigBuilder()
                 .persistPath(persistDir.toAbsolutePath().toString())
@@ -73,34 +73,11 @@ class PanamaEmbeddedBackupTest {
         try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath)) {
             EmbeddedSession session = runtime.startEmbedded(yaml);
             BackupResult<EmbeddedSession> result = session.backup(
-                    new BackupOptions.Builder(dest.toString()).leaveClosed(true).build());
+                    new BackupOptions.Builder(dest.toString()).leaveInactive(true).build());
 
             assertNull(result.session());
             assertNotNull(result.manifest());
             assertTrue(Files.exists(dest.resolve("backup_manifest.json")));
-        }
-    }
-
-    @Test
-    void embeddedBackupRejectsLeaveStopped(
-            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
-            @TempDir Path backupDir) {
-        String libPath = System.getenv("CHROMA_LIB_PATH");
-        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
-
-        String yaml = new EmbeddedConfigBuilder()
-                .persistPath(persistDir.toAbsolutePath().toString())
-                .allowReset(true)
-                .build();
-
-        Path dest = backupDir.resolve("output");
-
-        try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath);
-             EmbeddedSession session = runtime.startEmbedded(yaml)) {
-            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                    () -> session.backup(
-                            new BackupOptions.Builder(dest.toString()).leaveStopped(true).build()));
-            assertTrue(ex.getMessage().contains("leaveStopped"));
         }
     }
 

--- a/java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaEmbeddedBackupTest.java
+++ b/java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaEmbeddedBackupTest.java
@@ -1,0 +1,146 @@
+package tech.amikos.chroma.local.panama;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+import tech.amikos.chroma.local.core.BackupOptions;
+import tech.amikos.chroma.local.core.BackupResult;
+import tech.amikos.chroma.local.core.EmbeddedConfigBuilder;
+import tech.amikos.chroma.local.core.EmbeddedSession;
+
+class PanamaEmbeddedBackupTest {
+
+    @Test
+    void embeddedBackupCreatesDirectoryWithManifest(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        Files.writeString(persistDir.resolve("sentinel.txt"), "backup-test-data");
+
+        String yaml = new EmbeddedConfigBuilder()
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath)) {
+            EmbeddedSession session = runtime.startEmbedded(yaml);
+            BackupResult<EmbeddedSession> result = session.backup(
+                    new BackupOptions.Builder(dest.toString()).includeMetadata(true).build());
+
+            assertNotNull(result.manifest());
+            assertEquals("v1", result.manifest().schemaVersion());
+            assertEquals("embedded", result.manifest().mode());
+            assertTrue(result.manifest().fileCount() >= 1);
+            assertTrue(Files.exists(dest.resolve("persist").resolve("sentinel.txt")));
+            assertEquals("backup-test-data",
+                    Files.readString(dest.resolve("persist").resolve("sentinel.txt")));
+            assertTrue(Files.exists(dest.resolve("backup_manifest.json")));
+            assertNotNull(result.session());
+
+            result.session().close();
+        }
+    }
+
+    @Test
+    void embeddedBackupWithLeaveClosed(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        Files.writeString(persistDir.resolve("sentinel.txt"), "leave-closed-test");
+
+        String yaml = new EmbeddedConfigBuilder()
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath)) {
+            EmbeddedSession session = runtime.startEmbedded(yaml);
+            BackupResult<EmbeddedSession> result = session.backup(
+                    new BackupOptions.Builder(dest.toString()).leaveClosed(true).build());
+
+            assertNull(result.session());
+            assertNotNull(result.manifest());
+            assertTrue(Files.exists(dest.resolve("backup_manifest.json")));
+        }
+    }
+
+    @Test
+    void embeddedBackupRejectsLeaveStopped(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        String yaml = new EmbeddedConfigBuilder()
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath);
+             EmbeddedSession session = runtime.startEmbedded(yaml)) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> session.backup(
+                            new BackupOptions.Builder(dest.toString()).leaveStopped(true).build()));
+            assertTrue(ex.getMessage().contains("leaveStopped"));
+        }
+    }
+
+    @Test
+    void embeddedBackupRejectsNullOptions(@TempDir(cleanup = CleanupMode.NEVER) Path persistDir) {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        String yaml = new EmbeddedConfigBuilder()
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath);
+             EmbeddedSession session = runtime.startEmbedded(yaml)) {
+            assertThrows(IllegalArgumentException.class, () -> session.backup(null));
+        }
+    }
+
+    @Test
+    void embeddedBackupThrowsAfterClose(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        String yaml = new EmbeddedConfigBuilder()
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath)) {
+            EmbeddedSession session = runtime.startEmbedded(yaml);
+            session.close();
+
+            assertThrows(IllegalStateException.class,
+                    () -> session.backup(
+                            new BackupOptions.Builder(dest.toString()).build()));
+        }
+    }
+}

--- a/java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaServerBackupTest.java
+++ b/java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaServerBackupTest.java
@@ -1,0 +1,173 @@
+package tech.amikos.chroma.local.panama;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+import tech.amikos.chroma.local.core.BackupOptions;
+import tech.amikos.chroma.local.core.BackupResult;
+import tech.amikos.chroma.local.core.ServerConfigBuilder;
+import tech.amikos.chroma.local.core.ServerSession;
+
+class PanamaServerBackupTest {
+
+    @Test
+    void serverBackupCreatesDirectoryWithManifest(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        Files.writeString(persistDir.resolve("sentinel.txt"), "server-backup-test");
+
+        int port = findFreePort();
+        String yaml = new ServerConfigBuilder()
+                .port(port)
+                .listenAddress("127.0.0.1")
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath)) {
+            ServerSession session = runtime.startServer(yaml);
+            BackupResult<ServerSession> result = session.backup(
+                    new BackupOptions.Builder(dest.toString()).includeMetadata(true).build());
+
+            assertNotNull(result.manifest());
+            assertEquals("v1", result.manifest().schemaVersion());
+            assertEquals("server", result.manifest().mode());
+            assertTrue(result.manifest().fileCount() >= 1);
+            assertTrue(Files.exists(dest.resolve("persist").resolve("sentinel.txt")));
+            assertTrue(Files.exists(dest.resolve("backup_manifest.json")));
+            assertNotNull(result.session());
+            assertTrue(result.session().port() > 0);
+
+            result.session().close();
+        }
+    }
+
+    @Test
+    void serverBackupWithLeaveStopped(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        Files.writeString(persistDir.resolve("sentinel.txt"), "leave-stopped-test");
+
+        int port = findFreePort();
+        String yaml = new ServerConfigBuilder()
+                .port(port)
+                .listenAddress("127.0.0.1")
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath)) {
+            ServerSession session = runtime.startServer(yaml);
+            BackupResult<ServerSession> result = session.backup(
+                    new BackupOptions.Builder(dest.toString()).leaveStopped(true).build());
+
+            assertNull(result.session());
+            assertNotNull(result.manifest());
+            assertTrue(Files.exists(dest.resolve("backup_manifest.json")));
+        }
+    }
+
+    @Test
+    void serverBackupRejectsLeaveClosed(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        int port = findFreePort();
+        String yaml = new ServerConfigBuilder()
+                .port(port)
+                .listenAddress("127.0.0.1")
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath)) {
+            ServerSession session = runtime.startServer(yaml);
+            try {
+                IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                        () -> session.backup(
+                                new BackupOptions.Builder(dest.toString()).leaveClosed(true).build()));
+                assertTrue(ex.getMessage().contains("leaveClosed"));
+            } finally {
+                session.close();
+            }
+        }
+    }
+
+    @Test
+    void serverBackupRejectsNullOptions(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        int port = findFreePort();
+        String yaml = new ServerConfigBuilder()
+                .port(port)
+                .listenAddress("127.0.0.1")
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath);
+             ServerSession session = runtime.startServer(yaml)) {
+            assertThrows(IllegalArgumentException.class, () -> session.backup(null));
+        }
+    }
+
+    @Test
+    void serverBackupThrowsAfterClose(
+            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
+            @TempDir Path backupDir) throws Exception {
+        String libPath = System.getenv("CHROMA_LIB_PATH");
+        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
+
+        int port = findFreePort();
+        String yaml = new ServerConfigBuilder()
+                .port(port)
+                .listenAddress("127.0.0.1")
+                .persistPath(persistDir.toAbsolutePath().toString())
+                .allowReset(true)
+                .build();
+
+        Path dest = backupDir.resolve("output");
+
+        try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath)) {
+            ServerSession session = runtime.startServer(yaml);
+            session.close();
+
+            assertThrows(IllegalStateException.class,
+                    () -> session.backup(
+                            new BackupOptions.Builder(dest.toString()).build()));
+        }
+    }
+
+    private static int findFreePort() throws IOException {
+        try (ServerSocket s = new ServerSocket(0)) {
+            return s.getLocalPort();
+        }
+    }
+}

--- a/java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaServerBackupTest.java
+++ b/java/panama/src/test/java/tech/amikos/chroma/local/panama/PanamaServerBackupTest.java
@@ -59,13 +59,13 @@ class PanamaServerBackupTest {
     }
 
     @Test
-    void serverBackupWithLeaveStopped(
+    void serverBackupWithLeaveInactive(
             @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
             @TempDir Path backupDir) throws Exception {
         String libPath = System.getenv("CHROMA_LIB_PATH");
         Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
 
-        Files.writeString(persistDir.resolve("sentinel.txt"), "leave-stopped-test");
+        Files.writeString(persistDir.resolve("sentinel.txt"), "leave-inactive-test");
 
         int port = findFreePort();
         String yaml = new ServerConfigBuilder()
@@ -80,41 +80,11 @@ class PanamaServerBackupTest {
         try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath)) {
             ServerSession session = runtime.startServer(yaml);
             BackupResult<ServerSession> result = session.backup(
-                    new BackupOptions.Builder(dest.toString()).leaveStopped(true).build());
+                    new BackupOptions.Builder(dest.toString()).leaveInactive(true).build());
 
             assertNull(result.session());
             assertNotNull(result.manifest());
             assertTrue(Files.exists(dest.resolve("backup_manifest.json")));
-        }
-    }
-
-    @Test
-    void serverBackupRejectsLeaveClosed(
-            @TempDir(cleanup = CleanupMode.NEVER) Path persistDir,
-            @TempDir Path backupDir) throws Exception {
-        String libPath = System.getenv("CHROMA_LIB_PATH");
-        Assumptions.assumeTrue(libPath != null && !libPath.isBlank(), "CHROMA_LIB_PATH is required");
-
-        int port = findFreePort();
-        String yaml = new ServerConfigBuilder()
-                .port(port)
-                .listenAddress("127.0.0.1")
-                .persistPath(persistDir.toAbsolutePath().toString())
-                .allowReset(true)
-                .build();
-
-        Path dest = backupDir.resolve("output");
-
-        try (PanamaChromaRuntime runtime = PanamaChromaRuntime.init(libPath)) {
-            ServerSession session = runtime.startServer(yaml);
-            try {
-                IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                        () -> session.backup(
-                                new BackupOptions.Builder(dest.toString()).leaveClosed(true).build()));
-                assertTrue(ex.getMessage().contains("leaveClosed"));
-            } finally {
-                session.close();
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

**Phase 9: Backup API**
**Goal:** Users can back up Chroma data from both embedded and server modes, producing a directory with a manifest file that records backup metadata
**Status:** Verified (6/6 must-haves)

Implements Java backup API across core, JNA, and Panama modules. `BackupExecutor` handles the close-copy-manifest-restart lifecycle with transactional error handling. Both `EmbeddedSession.backup()` and `ServerSession.backup()` delegate to this executor with mode-specific close/restart actions. Produces a backup directory containing a `persist/` snapshot and `backup_manifest.json` with SHA-256 checksums.

## Changes

### Plan 01: Core backup implementation
- `BackupExecutor` — static utility implementing close-copy-manifest-restart with cleanup-on-failure
- `BackupResult<S>` — generic record wrapping manifest + new session
- `BackupMode` — enum for embedded/server wire format
- `BackupOptions` — builder with destination, includeMetadata, leaveInactive flags
- Backup callback slots wired into `EmbeddedSession` and `ServerSession`
- JNA and Panama runtimes construct backup lambdas with config extraction and session restart

### Plan 02: Integration tests
- JNA embedded + server backup tests (5 methods each)
- Panama embedded + server backup tests (5 methods each)
- Sentinel file verification, manifest parsing, mode-specific validation

### Review fixes (18 findings addressed)
- Fix native handle leak on pre-validation failure
- Fix premature backup directory deletion when restart succeeds
- Reject non-existent source path instead of silent empty backup
- Narrow exception catch to IOException only
- Propagate IOException in deleteDirectoryQuietly
- Return "0644" fallback on non-POSIX instead of null
- Remove dead Gson no-arg constructor from BackupManifest
- Add numeric bounds checks on fileCount/totalBytes/sizeBytes
- Replace internal "Phase 10" references with user-facing messages
- Remove dead BackupOptions.toJson()
- Add 12 new test methods covering null rejection, list immutability, session lifecycle

## Requirements Addressed

- **BKUP-01**: `EmbeddedSession.backup(options)` performs directory copy with manifest
- **BKUP-02**: `ServerSession.backup(options)` performs stop-backup-restart cycle
- **BKUP-03**: `BackupOptions` builder supports destination, includeMetadata, leaveInactive
- **BKUP-04**: Integration tests verify backup in both JNA and Panama backends

## Verification

- [x] Automated verification: 6/6 must-haves passed
- [x] UAT: 7/7 scenarios passed
- [x] Code review: 18 findings identified and fixed

## Key Files

**Created:**
- `java/core/.../BackupExecutor.java` — core backup algorithm
- `java/core/.../BackupResult.java` — generic result record
- `java/core/.../BackupMode.java` — embedded/server enum
- `java/core/.../BackupFileMetadataTest.java` — metadata validation tests
- `java/jna/.../JnaEmbeddedBackupTest.java` + `JnaServerBackupTest.java`
- `java/panama/.../PanamaEmbeddedBackupTest.java` + `PanamaServerBackupTest.java`

**Modified:**
- `java/core/.../EmbeddedSession.java` — backup method + lock
- `java/core/.../ServerSession.java` — backup method + lock
- `java/core/.../BackupManifest.java` — bounds checks, removed dead constructor
- `java/core/.../BackupOptions.java` — removed dead toJson
- `java/jna/.../JnaChromaRuntime.java` — backup lambda construction
- `java/panama/.../PanamaChromaRuntime.java` — backup lambda construction