### PR TITLE
fix(ci): use stable Go toolchain for build-test-lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go.mod
+          go-version: stable
           cache: true
 
       - name: Set up Rust

--- a/internal/runtime/embedded.go
+++ b/internal/runtime/embedded.go
@@ -1449,7 +1449,7 @@ func normalizeMetadataValue(path string, value any, allowNil bool) (any, error) 
 			return nil, errors.Errorf("%s float metadata values must be finite", path)
 		}
 		return metadataFloat64(f), nil
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if rv.IsNil() {
 			if allowNil {
 				return nil, nil


### PR DESCRIPTION
## Summary
- macOS CI (\`Build/Test/Lint (macos-latest)\`) was failing with \`dyld: missing LC_UUID load command\` on \`go test\` binaries
- Root cause: the job installs Go via \`go-version-file: go.mod\`, which resolves to the pinned \`go 1.21.13\`. Go's linker didn't emit an \`LC_UUID\` load command until 1.26.1, and macOS 26 (Tahoe) runners now reject binaries missing it ([golang/go#68678](https://github.com/golang/go/issues/68678), [#78012](https://github.com/golang/go/issues/78012))
- Switches to \`go-version: stable\`, matching the existing \`api-compat\` job, so CI runs a current Go toolchain while \`go.mod\`'s \`go 1.21\` compatibility floor for downstream consumers is untouched

## Test plan
- [x] CI green on this PR (build-test-lint macOS job specifically)