### PR TITLE
fix(ci): stop release signing identity from mismatching the released ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,31 @@ jobs:
           sha256sum -- "${files[@]}" > SHA256SUMS
           ls -lah
 
+      # Guard for issue #100: cosign derives the certificate identity from
+      # github.workflow_ref (the ref the workflow FILE was loaded from), not the
+      # ref that actions/checkout pulled. Dispatching from main therefore signs
+      # tag content with a refs/heads/main identity, forcing downstream consumers
+      # to widen their cosign allowlist. Refuse to sign on mismatch.
+      # NOTE: this holds only while the signing job lives in this file — if it
+      # ever moves to a reusable workflow the identity follows job_workflow_ref.
+      - name: Verify signing identity matches released ref
+        shell: bash
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          EXPECTED_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.release_tag) || github.ref }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          SIGNING_REF="${WORKFLOW_REF##*@}"
+          if [ "${SIGNING_REF}" != "${EXPECTED_REF}" ]; then
+            echo "::error title=Signing identity mismatch::Artifacts would be signed as release.yml@${SIGNING_REF} but were built from ${EXPECTED_REF}"
+            echo "Refusing to sign: the cosign certificate identity must match the released ref (see issue #100)."
+            echo "Re-run the release from the tag itself:"
+            echo "  gh workflow run release.yml --ref ${RELEASE_TAG} -f release_tag=${RELEASE_TAG}"
+            exit 1
+          fi
+          echo "Signing identity ref ${SIGNING_REF} matches released ref ${EXPECTED_REF}."
+
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,12 @@ on:
 permissions:
   contents: read
 
+env:
+  # Single source of truth for the ref being released. Both `actions/checkout`
+  # steps and the signing-identity guard read this, so the ref that gets built
+  # and the ref the guard validates cannot drift apart.
+  RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.release_tag) || github.ref }}
+
 jobs:
   build-artifacts:
     name: Build Artifact (${{ matrix.os }})
@@ -30,7 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.release_tag) || github.ref }}
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Normalize line endings on Windows
         if: runner.os == 'Windows'
@@ -125,7 +131,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.release_tag) || github.ref }}
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Set up Java 17
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
@@ -258,25 +264,27 @@ jobs:
       # ref that actions/checkout pulled. Dispatching from main therefore signs
       # tag content with a refs/heads/main identity, forcing downstream consumers
       # to widen their cosign allowlist. Refuse to sign on mismatch.
+      # The whole identity (repo + workflow path + ref) is compared exactly:
+      # splitting workflow_ref on '@' is spoofable because git refs may legally
+      # contain '@', so a branch named "x@refs/tags/v1.2.3" would forge a match.
       # NOTE: this holds only while the signing job lives in this file — if it
       # ever moves to a reusable workflow the identity follows job_workflow_ref.
       - name: Verify signing identity matches released ref
         shell: bash
         env:
           WORKFLOW_REF: ${{ github.workflow_ref }}
-          EXPECTED_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.release_tag) || github.ref }}
+          EXPECTED_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/release.yml@${{ env.RELEASE_REF }}
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
         run: |
           set -euo pipefail
-          SIGNING_REF="${WORKFLOW_REF##*@}"
-          if [ "${SIGNING_REF}" != "${EXPECTED_REF}" ]; then
-            echo "::error title=Signing identity mismatch::Artifacts would be signed as release.yml@${SIGNING_REF} but were built from ${EXPECTED_REF}"
+          if [ "${WORKFLOW_REF}" != "${EXPECTED_WORKFLOW_REF}" ]; then
+            echo "::error title=Signing identity mismatch::Artifacts would be signed as ${WORKFLOW_REF} but must be ${EXPECTED_WORKFLOW_REF}"
             echo "Refusing to sign: the cosign certificate identity must match the released ref (see issue #100)."
             echo "Re-run the release from the tag itself:"
             echo "  gh workflow run release.yml --ref ${RELEASE_TAG} -f release_tag=${RELEASE_TAG}"
             exit 1
           fi
-          echo "Signing identity ref ${SIGNING_REF} matches released ref ${EXPECTED_REF}."
+          echo "Signing identity ${WORKFLOW_REF} matches the released ref."
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -75,7 +75,15 @@ None yet.
 
 None yet.
 
+### Quick Tasks Completed
+
+| # | Description | Date | Commit | Status | Directory |
+|---|-------------|------|--------|--------|-----------|
+| 260730-ggr | Fix issue #100: release workflow signs with refs/heads/main identity instead of refs/tags/<version> when dispatched from main | 2026-07-30 | 4a5d7aa | Verified | [260730-ggr-fix-issue-100-release-workflow-signs-wit](./quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/) |
+
 ## Session Continuity
+
+Last activity: 2026-07-30 - Completed quick task 260730-ggr: Fix issue #100: release workflow signs with refs/heads/main identity instead of refs/tags/<version> when dispatched from main
 
 Last session: 2026-03-28T09:41:20Z
 Stopped at: Completed 10-02-PLAN.md

--- a/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-CONTEXT.md
+++ b/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-CONTEXT.md
@@ -1,0 +1,51 @@
+# Quick Task 260730-ggr: Fix issue #100: release workflow signs with refs/heads/main identity instead of refs/tags/<version> when dispatched from main - Context
+
+**Gathered:** 2026-07-30
+**Status:** Ready for planning
+
+<domain>
+## Task Boundary
+
+GitHub issue #100: `release.yml` runs via `workflow_dispatch` from `main`, builds artifacts from the checked-out tag, but signs them with the `refs/heads/main` cosign identity because the identity is derived from `github.workflow_ref` (the ref the workflow file itself was loaded from), not the ref that was actually checked out. This forces downstream consumers (chroma-go) to widen a cosign identity allowlist per affected release (v0.3.4, v0.3.5).
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Fix approach
+- Add a fail-loud CI guard to `release.yml`. Do NOT restructure into a reusable workflow (`workflow_call`) and do NOT rely on a process-only/documentation-only fix. The workflow itself must refuse to proceed when the signing identity would not match the released ref.
+
+### Guard placement and behavior
+- Insert the check immediately before the cosign/signing step (around `.github/workflows/release.yml:265,289` where `WORKFLOW_REF`/`IDENTITY` are used).
+- Compare the ref embedded in `github.workflow_ref` against the ref that was actually checked out (on `workflow_dispatch`, that's `refs/tags/${{ github.event.inputs.release_tag }}`; on a tag-push trigger it's `github.ref`).
+- On mismatch, hard-fail the job (non-zero exit) with a clear error message pointing at the correct dispatch invocation (`gh workflow run release.yml --ref <tag> -f release_tag=<tag>`) — do not sign or publish artifacts.
+
+### Claude's Discretion
+- Exact bash/shell implementation of the ref comparison (e.g. string comparison of `github.workflow_ref` suffix vs. expected `refs/tags/<tag>`), as long as it fails loud on mismatch and passes for the correct tag-based invocation.
+- Whether to add a short comment/test note in the workflow explaining why the guard exists.
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+Issue text confirms the mismatch via a decoded `v0.3.5` sigstore bundle:
+```
+URI:https://github.com/amikos-tech/chroma-go-local/.github/workflows/release.yml@refs/heads/main
+1.3.6.1.4.1.57264.1.6:  refs/heads/main
+```
+Expected identity for a correctly-scoped release: `.../release.yml@refs/tags/<version>`.
+
+Acceptance criteria from the issue: a release published through the intended path signs as `release.yml@refs/tags/<version>`; no new allowlist entries are needed per release going forward.
+
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+- GitHub issue #100 (this repo) — full problem writeup and suggested fixes
+- Related: issue #99 (published tags are unprotected — root cause of the original re-tag that started this)
+- Related downstream: amikos-tech/chroma-go#512, #514 (the widened cosign allowlist this fix aims to stop growing)
+
+</canonical_refs>

--- a/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-PLAN.md
+++ b/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-PLAN.md
@@ -1,0 +1,279 @@
+---
+phase: quick/260730-ggr
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - .github/workflows/release.yml
+autonomous: true
+requirements: [ISSUE-100]
+
+must_haves:
+  truths:
+    - "The release workflow hard-fails before signing when the ref baked into github.workflow_ref differs from the ref that was actually built"
+    - "The guard passes unchanged for a tag push (v* tag) and for a workflow_dispatch started on the tag itself"
+    - "On mismatch the run summary shows an error annotation naming both refs and the exact `gh workflow run release.yml --ref <tag> -f release_tag=<tag>` remediation command"
+    - "No artifact is signed, uploaded to R2, or published to a GitHub release when the guard fails"
+    - "release.yml remains valid GitHub Actions syntax (actionlint clean) and the guard bash is shellcheck clean"
+  artifacts:
+    - path: ".github/workflows/release.yml"
+      provides: "publish-release step 'Verify signing identity matches released ref' placed before 'Install cosign'"
+      contains: "Verify signing identity matches released ref"
+  key_links:
+    - from: "guard step env WORKFLOW_REF"
+      to: "github.workflow_ref context"
+      via: "env: block (never inlined into run:)"
+      pattern: "WORKFLOW_REF: \\$\\{\\{ github.workflow_ref \\}\\}"
+    - from: "guard step env EXPECTED_REF"
+      to: "the same ternary used by actions/checkout at release.yml:33 and :128"
+      via: "verbatim expression reuse so guard and checkout cannot drift"
+      pattern: "format\\('refs/tags/\\{0\\}', github.event.inputs.release_tag\\) \\|\\| github.ref"
+    - from: "guard step position"
+      to: "'Install cosign' / 'Sign and verify artifacts' / 'Upload artifacts to R2' / 'Publish GitHub release'"
+      via: "non-zero exit skips all subsequent steps in the job"
+      pattern: "steps ordered: Build checksum manifest -> guard -> Install cosign"
+---
+
+<objective>
+Add a fail-loud guard to `.github/workflows/release.yml` that refuses to sign release artifacts when the cosign keyless identity would not match the ref the artifacts were built from (GitHub issue #100).
+
+Purpose: cosign derives the certificate SAN from the OIDC `job_workflow_ref` claim — i.e. the ref the workflow *file* was loaded from — not from whatever `actions/checkout` pulled. Dispatching `release.yml` from `main` therefore builds tag content but signs it `release.yml@refs/heads/main`, forcing downstream consumers (chroma-go) to widen their cosign identity allowlist for every affected release. The identity cannot be overridden from inside the workflow, so the only correct fix is to detect the mismatch and refuse to proceed.
+
+Output: one new `shell: bash` step in the `publish-release` job. No other workflow changes, no reusable-workflow restructuring, no docs-only fix.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-CONTEXT.md
+@.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-RESEARCH.md
+@.github/workflows/release.yml
+
+The RESEARCH.md section **"Proposed Guard Step (validated)"** contains the exact YAML to insert. It was
+already validated locally with `actionlint` v1.7.11, `yq` v4.53.3, `shellcheck`, and four behavioral cases.
+Use it as written — Task 1 is an insertion, not a redesign.
+
+Read RESEARCH.md **"Gotchas"** before editing. Load-bearing points:
+- `${WORKFLOW_REF##*@}` (strip through the LAST `@`). `%%@*` is wrong — it yields the repo/path prefix.
+- `github.event.inputs` is null outside `workflow_dispatch`; the `event_name == 'workflow_dispatch' && ... || ...`
+  ternary short-circuits before `format()` runs. Reuse the existing shape from lines 33/128/151 rather than
+  inventing a new expression.
+- Never inline `${{ github.event.inputs.release_tag }}` into a `run:` body — script-injection sink. Pass via `env:`.
+- Do NOT add normalization/sanitization for a malformed `release_tag`; failing loud is intended (Gotcha 3).
+</context>
+
+<interfaces>
+Existing expressions in `.github/workflows/release.yml` that the guard must reuse verbatim:
+
+- Built ref (used by `actions/checkout` at lines 33 and 128):
+  `${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.release_tag) || github.ref }}`
+- Bare tag name (used at lines 151, 219, 313, 404):
+  `${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}`
+- Signing identity, consumed twice (lines 265-269 and 316/359):
+  `WORKFLOW_REF: ${{ github.workflow_ref }}` then `IDENTITY="https://github.com/${WORKFLOW_REF}"`
+
+Current `publish-release` step order (names are the stable handle for verification):
+`Checkout repository scripts` -> `Download artifact bundles` -> `Download Java artifact bundles` ->
+`Normalize artifact names` -> `Build checksum manifest` -> **[insert guard here]** -> `Install cosign` ->
+`Sign and verify artifacts` -> `Upload artifacts to R2` -> `Purge release metadata from CDN cache` ->
+`Publish GitHub release`
+</interfaces>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Insert the signing-identity guard into publish-release</name>
+  <files>.github/workflows/release.yml</files>
+  <action>
+Insert a single new step named exactly `Verify signing identity matches released ref` into the
+`publish-release` job, immediately before the existing `- name: Install cosign` step (currently line 256)
+and immediately after `Build checksum manifest`. Copy the YAML verbatim from the RESEARCH.md section
+"Proposed Guard Step (validated)", including its leading comment block.
+
+Structural requirements for the step:
+- `shell: bash`.
+- Three `env:` keys, no `${{ }}` interpolation anywhere inside `run:`:
+  - `WORKFLOW_REF` -> `${{ github.workflow_ref }}`
+  - `EXPECTED_REF` -> the checkout ternary reproduced verbatim from line 33
+  - `RELEASE_TAG` -> the bare-tag ternary reproduced verbatim from line 151
+- `run:` body opens with `set -euo pipefail` (house style, 8 existing occurrences in this file), derives
+  `SIGNING_REF="${WORKFLOW_REF##*@}"`, and compares it against `EXPECTED_REF`.
+- On mismatch: emit a `::error title=Signing identity mismatch::` annotation naming both refs, print the
+  refusal reason with an issue #100 reference, print the copy-pasteable
+  `gh workflow run release.yml --ref "${RELEASE_TAG}" -f release_tag="${RELEASE_TAG}"` remediation, then
+  `exit 1`. On match: print a one-line confirmation and fall through.
+- Quote every variable expansion.
+
+Keep the comment block: it records *why* the guard exists (identity comes from `workflow_ref`, not the
+checkout) and the caveat that the premise holds only while signing stays inline in this file — neither is
+inferable from the code. Per CLAUDE.md, that is the one warranted comment; add nothing beyond it.
+
+Do not touch any other step. Do not add a second guard to the build jobs, do not add a `workflow_call`
+trigger, and do not modify the `publish-release` `if:` gate at line 193.
+  </action>
+  <verify>
+    <automated>
+cd /Users/tazarov/experiments/amikos/local-go-chroma
+set -euo pipefail
+
+# 1. Workflow still valid Actions syntax
+actionlint .github/workflows/release.yml
+
+# 2. Guard exists and lands before the cosign install
+NAMES=$(yq -r '.jobs.publish-release.steps[].name' .github/workflows/release.yml)
+G=$(printf '%s\n' "$NAMES" | grep -n '^Verify signing identity matches released ref$' | cut -d: -f1)
+C=$(printf '%s\n' "$NAMES" | grep -n '^Install cosign$' | cut -d: -f1)
+B=$(printf '%s\n' "$NAMES" | grep -n '^Build checksum manifest$' | cut -d: -f1)
+test -n "$G" && test "$B" -lt "$G" && test "$G" -lt "$C"
+
+# 3. Guard bash is shellcheck clean
+yq -r '.jobs.publish-release.steps[] | select(.name == "Verify signing identity matches released ref") | .run' \
+  .github/workflows/release.yml | shellcheck -s bash -
+
+# 4. No script-injection sink: no ${{ }} inside the guard run body
+! yq -r '.jobs.publish-release.steps[] | select(.name == "Verify signing identity matches released ref") | .run' \
+  .github/workflows/release.yml | grep -q '\${{'
+
+# 5. Guard reads the identity from github.workflow_ref, not a reinvented value
+yq -r '.jobs.publish-release.steps[] | select(.name == "Verify signing identity matches released ref") | .env.WORKFLOW_REF' \
+  .github/workflows/release.yml | grep -q 'github.workflow_ref'
+
+# 6. EXPECTED_REF matches the checkout ternary byte-for-byte
+CHECKOUT_REF=$(yq -r '.jobs.build-artifacts.steps[] | select(.name == "Checkout") | .with.ref' .github/workflows/release.yml)
+GUARD_REF=$(yq -r '.jobs.publish-release.steps[] | select(.name == "Verify signing identity matches released ref") | .env.EXPECTED_REF' .github/workflows/release.yml)
+test "$CHECKOUT_REF" = "$GUARD_REF"
+    </automated>
+  </verify>
+  <done>
+`actionlint` is clean; `yq` reports the guard step positioned between `Build checksum manifest` and
+`Install cosign`; the guard's bash passes `shellcheck -s bash`; the `run:` body contains zero `${{`
+sequences; `EXPECTED_REF` is byte-identical to the `build-artifacts` checkout `ref` expression.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Prove the guard's exit-code matrix locally</name>
+  <files>.github/workflows/release.yml (read-only — no modifications in this task)</files>
+  <action>
+Extract the guard's `run:` body straight out of the committed YAML with `yq` and execute it under the four
+environment combinations from RESEARCH.md "Local Validation Performed", asserting exit codes. Extracting
+from the YAML (rather than re-typing the script) is what makes this a real regression check on the shipped
+artifact.
+
+Expected matrix:
+- Case A — dispatch from `main`, `release_tag=v0.3.6` (`WORKFLOW_REF` ends `@refs/heads/main`,
+  `EXPECTED_REF=refs/tags/v0.3.6`) -> exit 1. This is the issue #100 bug.
+- Case B — dispatch from tag `v0.3.6` (both refs `refs/tags/v0.3.6`) -> exit 0.
+- Case C — tag push `v0.3.6` (same values as B, since `github.ref` is the tag) -> exit 0.
+- Case D — dispatched on `v0.3.6` but `release_tag=v0.3.5` -> exit 1. Free bonus catch: build would check
+  out `v0.3.5` while signing as `v0.3.6`.
+
+Also confirm the Case A stderr/stdout contains the remediation command with the correct tag substituted,
+so an operator hitting this in CI is not left guessing.
+
+If any case deviates, fix the guard in Task 1's file rather than adjusting the expectations — the matrix
+is the specification.
+
+Write no new files. This is verification only; no test script is committed (out of scope per CONTEXT.md).
+  </action>
+  <verify>
+    <automated>
+cd /Users/tazarov/experiments/amikos/local-go-chroma
+set -euo pipefail
+
+GUARD=$(yq -r '.jobs.publish-release.steps[] | select(.name == "Verify signing identity matches released ref") | .run' .github/workflows/release.yml)
+test -n "$GUARD"
+REPO_PATH='amikos-tech/chroma-go-local/.github/workflows/release.yml'
+
+run_case() {
+  set +e
+  env WORKFLOW_REF="$1" EXPECTED_REF="$2" RELEASE_TAG="$3" bash -c "$GUARD" >/tmp/guard.out 2>&1
+  local rc=$?
+  set -e
+  echo "$rc"
+}
+
+# Case A: dispatch from main -> must refuse
+test "$(run_case "${REPO_PATH}@refs/heads/main" 'refs/tags/v0.3.6' 'v0.3.6')" = "1"
+grep -q 'gh workflow run release.yml --ref' /tmp/guard.out
+grep -q 'v0.3.6' /tmp/guard.out
+grep -q 'Signing identity mismatch' /tmp/guard.out
+
+# Case B: dispatch from the tag -> must pass
+test "$(run_case "${REPO_PATH}@refs/tags/v0.3.6" 'refs/tags/v0.3.6' 'v0.3.6')" = "0"
+
+# Case C: tag push -> must pass
+test "$(run_case "${REPO_PATH}@refs/tags/v0.3.6" 'refs/tags/v0.3.6' 'v0.3.6')" = "0"
+
+# Case D: dispatched on v0.3.6 with release_tag=v0.3.5 -> must refuse
+test "$(run_case "${REPO_PATH}@refs/tags/v0.3.6" 'refs/tags/v0.3.5' 'v0.3.5')" = "1"
+
+rm -f /tmp/guard.out
+echo "guard matrix A=1 B=0 C=0 D=1 confirmed"
+    </automated>
+  </verify>
+  <done>
+All four cases produce the expected exit codes (A=1, B=0, C=0, D=1) against the script extracted from the
+committed `release.yml`, and the Case A output contains the `Signing identity mismatch` annotation plus the
+tag-substituted `gh workflow run release.yml --ref ...` remediation line.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| operator -> `workflow_dispatch` input | `release_tag` is free-form untrusted string entering a CI shell |
+| GitHub OIDC -> Fulcio -> downstream verifier | certificate identity is the trust anchor consumers pin |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-ggr-01 | Spoofing | cosign identity in `Sign and verify artifacts` | mitigate | The guard itself: refuse to sign when `${WORKFLOW_REF##*@}` != the built ref, so a `refs/heads/main` identity can never be attached to tag content (issue #100 root cause) |
+| T-ggr-02 | Tampering / EoP | guard `run:` body | mitigate | `release_tag` reaches the shell only via `env: RELEASE_TAG`; zero `${{ }}` inside `run:` (asserted by Task 1 verify check 4); all expansions quoted |
+| T-ggr-03 | Spoofing | downstream chroma-go allowlist | mitigate | Fixing the root cause stops per-release allowlist growth and lets the `v0.3.4`/`v0.3.5` exceptions be retired |
+| T-ggr-04 | Spoofing | future `workflow_call` refactor | accept | SAN comes from `job_workflow_ref`, which has no matching context expression; recorded in the step's inline comment so a reusable-workflow refactor cannot silently defeat the guard |
+| T-ggr-SC | Tampering | npm/pip/cargo installs | n/a | No package installs in this change; `actionlint`/`yq`/`shellcheck`/`cosign` are pre-installed locally, all workflow actions remain SHA-pinned and unmodified |
+</threat_model>
+
+<verification>
+Full static suite (CLAUDE.md mandates `yq` for YAML validation):
+
+```
+actionlint .github/workflows/*.yml
+yq '.jobs.publish-release.steps | map(.name)' .github/workflows/release.yml
+git diff --stat   # must show exactly one file, .github/workflows/release.yml
+```
+
+The diff must be additive-only within `publish-release`: no changed action SHAs, no altered `if:` gates, no
+edits to `build-artifacts` or `build-java-artifacts`.
+
+**Deferred, manual, post-merge:** end-to-end identity confirmation requires a real tag plus live OIDC. On
+the next release run `cosign verify-blob --bundle <artifact>.sigstore.json --certificate-identity
+"https://github.com/amikos-tech/chroma-go-local/.github/workflows/release.yml@refs/tags/<version>"
+--certificate-oidc-issuer "https://token.actions.githubusercontent.com" --use-signed-timestamps <artifact>`
+and confirm it passes without an allowlist widening. This cannot be automated pre-merge.
+</verification>
+
+<success_criteria>
+- [ ] `.github/workflows/release.yml` contains exactly one new step, `Verify signing identity matches released ref`, between `Build checksum manifest` and `Install cosign` in `publish-release`
+- [ ] `actionlint .github/workflows/*.yml` clean; guard `run:` body clean under `shellcheck -s bash`
+- [ ] Guard `EXPECTED_REF` is byte-identical to the `actions/checkout` ref ternary (no independent reimplementation)
+- [ ] Exit-code matrix confirmed: dispatch-from-main = 1, tag-dispatch = 0, tag-push = 0, mismatched-input = 1
+- [ ] Mismatch output carries an `::error title=Signing identity mismatch::` annotation and the tag-substituted `gh workflow run release.yml --ref <tag> -f release_tag=<tag>` command
+- [ ] No `${{ }}` interpolation inside the guard's `run:` body
+- [ ] `git diff` touches only `.github/workflows/release.yml`; no `workflow_call` trigger, no docs-only changes, no new files
+- [ ] Committed with a conventional commit (`fix(ci): ...`), no Claude Code attribution trailer, delivered via PR — never pushed straight to `main`
+</success_criteria>
+
+<output>
+Create `.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-RESEARCH.md
+++ b/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-RESEARCH.md
@@ -1,0 +1,320 @@
+# Quick Task 260730-ggr: Fix issue #100 (release workflow signs with wrong ref identity) - Research
+
+**Researched:** 2026-07-30
+**Domain:** GitHub Actions workflow contexts + Sigstore/cosign keyless identity
+**Confidence:** HIGH
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+**Fix approach**
+- Add a fail-loud CI guard to `release.yml`. Do NOT restructure into a reusable workflow (`workflow_call`) and do NOT rely on a process-only/documentation-only fix. The workflow itself must refuse to proceed when the signing identity would not match the released ref.
+
+**Guard placement and behavior**
+- Insert the check immediately before the cosign/signing step (around `.github/workflows/release.yml:265,289` where `WORKFLOW_REF`/`IDENTITY` are used).
+- Compare the ref embedded in `github.workflow_ref` against the ref that was actually checked out (on `workflow_dispatch`, that's `refs/tags/${{ github.event.inputs.release_tag }}`; on a tag-push trigger it's `github.ref`).
+- On mismatch, hard-fail the job (non-zero exit) with a clear error message pointing at the correct dispatch invocation (`gh workflow run release.yml --ref <tag> -f release_tag=<tag>`) — do not sign or publish artifacts.
+
+### Claude's Discretion
+- Exact bash/shell implementation of the ref comparison (e.g. string comparison of `github.workflow_ref` suffix vs. expected `refs/tags/<tag>`), as long as it fails loud on mismatch and passes for the correct tag-based invocation.
+- Whether to add a short comment/test note in the workflow explaining why the guard exists.
+
+### Deferred Ideas (OUT OF SCOPE)
+- `workflow_call` / reusable-workflow restructuring.
+- Documentation-only or process-only fixes.
+</user_constraints>
+
+## Summary
+
+The bug is fully explained by one fact: the cosign certificate SAN URI is built from the OIDC
+`job_workflow_ref` claim, which for a non-reusable workflow equals `github.workflow_ref` — the ref the
+**workflow file** was loaded from. `actions/checkout` at `release.yml:33` overrides the ref for the
+*build*, but nothing can override the ref baked into the OIDC token. So dispatch-from-`main` builds tag
+content and signs it `release.yml@refs/heads/main`. The only way to get a `refs/tags/<v>` identity is to
+start the run on the tag ref itself. [VERIFIED: docs.github.com + sigstore/fulcio oid-info.md]
+
+Dispatching on a tag ref is fully supported and **already proven in this repo**: run `22517529944`
+(`v0.3.0` backfill) was `event: workflow_dispatch` with `headBranch: v0.3.0`, and at `v0.3.0` the
+`publish-release` job gate was the bare `if: startsWith(github.ref, 'refs/tags/')` — it published, which
+proves `github.ref == refs/tags/v0.3.0` on a tag dispatch. [VERIFIED: gh run list / git show v0.3.0]
+
+Therefore the guard is purely a comparison of two values both available as expressions, needs no new
+inputs or permissions, and is ~12 lines of bash. A candidate patch was written and validated locally:
+`actionlint` clean, `yq` parses, `shellcheck` clean, and all four behavioral cases (dispatch-from-main,
+dispatch-from-tag, tag-push, tag-dispatch-with-mismatched-input) produce the correct exit codes.
+
+**Primary recommendation:** Insert one `shell: bash` step named **"Verify signing identity matches
+released ref"** immediately before `- name: Install cosign` (currently `.github/workflows/release.yml:256`)
+in the `publish-release` job. Compare `${WORKFLOW_REF##*@}` against the same ternary expression already
+used by the checkout steps. Pass all values via `env:` — never inline `${{ github.event.inputs.* }}` into
+the `run:` body.
+
+## Root-Cause Chain (verified)
+
+| Step | Evidence | Confidence |
+|------|----------|-----------|
+| `github.workflow_ref` = `owner/repo/.github/workflows/f.yml@<ref>` | "The ref path to the workflow. For example, `octocat/hello-world/.github/workflows/my-workflow.yml@refs/heads/my_branch`." [CITED: docs.github.com/en/actions/reference/workflows-and-actions/contexts] | HIGH |
+| cosign cert SAN comes from `job_workflow_ref`, not `ref` | Fulcio OID map: `1.3.6.1.4.1.57264.1.9` Build Signer URI = `server_url + job_workflow_ref` [CITED: github.com/sigstore/fulcio/blob/main/docs/oid-info.md] | HIGH |
+| `job_workflow_ref == workflow_ref` for non-reusable workflows | `job_workflow_ref` is documented as "For jobs using a reusable workflow, the ref path to the reusable workflow." Release logic lives inline in `release.yml`, so they coincide — confirmed by the decoded `v0.3.5` bundle in issue #100 showing `release.yml@refs/heads/main`. [VERIFIED: docs.github.com/en/actions/reference/security/oidc + issue #100 cert dump] | HIGH |
+| No expression exists to override the signing ref | There is no `github.job_workflow_ref` context property; `checkout` only affects the working tree. [VERIFIED: contexts reference — property absent] | HIGH |
+| `workflow_dispatch` accepts a tag as `ref` | "The git reference for the workflow. The reference can be a branch or tag name." [CITED: docs.github.com/en/rest/actions/workflows] | HIGH |
+| Tag dispatch sets `github.ref = refs/tags/<v>` | Run `22517529944` dispatched on `v0.3.0` passed a bare `startsWith(github.ref, 'refs/tags/')` gate. [VERIFIED: gh run list --workflow=release.yml; git show v0.3.0:.github/workflows/release.yml:109] | HIGH |
+
+Why this repo drifted to dispatch-from-main: the tag-push runs for both `v0.3.4` and `v0.3.5` **failed**
+(`gh run list` shows `push`/`v0.3.4` and `push`/`v0.3.5` with `conclusion: failure`), so both were
+backfilled by dispatch from `main`. The guard closes that escape hatch deliberately. [VERIFIED: gh run list]
+
+## Exact Insertion Point
+
+`publish-release` job step order today (verified via `yq '.jobs.publish-release.steps | map(.name)'`):
+
+| # | Step name | Line |
+|---|-----------|------|
+| 1 | Checkout repository scripts | 200 |
+| 2 | Download artifact bundles | 203 |
+| 3 | Download Java artifact bundles | 210 |
+| 4 | Normalize artifact names | 216 |
+| 5 | Build checksum manifest | 242 |
+| — | **← INSERT GUARD HERE** | **before 256** |
+| 6 | Install cosign | 256 |
+| 7 | Sign and verify artifacts | 262 (`WORKFLOW_REF` at 265, `IDENTITY` at 269) |
+| 8 | Upload artifacts to R2 | 306 (second `WORKFLOW_REF` at 316, second `IDENTITY` at 359) |
+| 9 | Purge release metadata from CDN cache | 381 |
+| 10 | Publish GitHub release | 401 |
+
+**One guard covers both signing sites.** `WORKFLOW_REF` is consumed twice (steps 7 and 8), but a
+non-zero exit at the guard fails the job and every later step is skipped — including the GitHub release
+publish at 401 and the R2 upload at 306. No second guard needed. [VERIFIED: Actions default step
+behavior — steps without `if:` do not run after a failure]
+
+**On placing it earlier (focus item 2):** placing it as the first step of `publish-release` saves only the
+artifact-download seconds, because `publish-release` has `needs: [build-artifacts, build-java-artifacts]`
+— all ~3-OS matrix build minutes are already spent before this job starts. Moving the guard into the
+build jobs would save real runner time but requires duplicating it across two jobs, which conflicts with
+CLAUDE.md's "radically simple" rule and with the locked "immediately before the cosign step" decision.
+Recommend the single placement above; see Open Questions if fail-fast matters more than simplicity.
+
+## Proposed Guard Step (validated)
+
+Insert verbatim before line 256 (`- name: Install cosign`):
+
+```yaml
+      # Guard for issue #100: cosign derives the certificate identity from
+      # github.workflow_ref (the ref the workflow FILE was loaded from), not the
+      # ref that actions/checkout pulled. Dispatching from main therefore signs
+      # tag content with a refs/heads/main identity, forcing downstream consumers
+      # to widen their cosign allowlist. Refuse to sign on mismatch.
+      # NOTE: this holds only while the signing job lives in this file — if it
+      # ever moves to a reusable workflow the identity follows job_workflow_ref.
+      - name: Verify signing identity matches released ref
+        shell: bash
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          EXPECTED_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.release_tag) || github.ref }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          SIGNING_REF="${WORKFLOW_REF##*@}"
+          if [ "${SIGNING_REF}" != "${EXPECTED_REF}" ]; then
+            echo "::error title=Signing identity mismatch::Artifacts would be signed as release.yml@${SIGNING_REF} but were built from ${EXPECTED_REF}"
+            echo "Refusing to sign: the cosign certificate identity must match the released ref (see issue #100)."
+            echo "Re-run the release from the tag itself:"
+            echo "  gh workflow run release.yml --ref ${RELEASE_TAG} -f release_tag=${RELEASE_TAG}"
+            exit 1
+          fi
+          echo "Signing identity ref ${SIGNING_REF} matches released ref ${EXPECTED_REF}."
+```
+
+Design notes:
+- `EXPECTED_REF` is the **identical ternary** already used at lines 33 and 128 for `actions/checkout`, so
+  the guard compares against literally the ref that was built — no independent reimplementation to drift.
+- `RELEASE_TAG` mirrors the ternary at lines 151/219/313 (`github.ref_name` fallback) so the remediation
+  command is copy-pasteable.
+- `${WORKFLOW_REF##*@}` strips through the **last** `@`. Safe: GitHub owner/repo names permit only
+  alphanumerics, `-`, `_`, `.` — no `@` — and the workflow path is `.github/workflows/release.yml`.
+  Do **not** use `%%@*` (that yields the repo/path prefix).
+- `set -euo pipefail` matches the existing house style (8 occurrences in this file).
+- `::error title=...::` renders an annotation on the run summary rather than burying the reason in logs.
+
+## Local Validation Performed
+
+| Check | Command | Result |
+|-------|---------|--------|
+| Workflow lints | `actionlint .github/workflows/release.yml` (on patched copy) | clean |
+| YAML parses / step order | `yq '.jobs.publish-release.steps \| map(.name)'` | guard lands between "Build checksum manifest" and "Install cosign" |
+| Shell lints | `shellcheck -s bash guard.sh` | clean |
+| Case A — dispatch from `main`, `release_tag=v0.3.6` | `WORKFLOW_REF=...@refs/heads/main EXPECTED_REF=refs/tags/v0.3.6` | **exit 1** with actionable message |
+| Case B — dispatch from tag `v0.3.6` | `WORKFLOW_REF=...@refs/tags/v0.3.6 EXPECTED_REF=refs/tags/v0.3.6` | exit 0 |
+| Case C — tag push `v0.3.6` | same values as B | exit 0 |
+| Case D — dispatched on `v0.3.6` but `release_tag=v0.3.5` | `EXPECTED_REF=refs/tags/v0.3.5` | **exit 1** (bonus catch) |
+
+Case D is a free extra: the guard also catches the "dispatched from the wrong tag" mistake, where the
+build would check out `v0.3.5` while signing as `v0.3.6`.
+
+## Gotchas
+
+### 1. Never inline `github.event.inputs.release_tag` into a `run:` body
+`release_tag` is free-form user input. Inlining `${{ github.event.inputs.release_tag }}` inside a `run:`
+block is a script-injection sink (GitHub's documented untrusted-input class). Pass it through `env:` and
+reference `"${RELEASE_TAG}"` — which is what lines 218-220 and 264-265 already do correctly.
+[CITED: docs.github.com — Security hardening for GitHub Actions, script injection]
+
+### 2. `github.event.inputs` is null outside `workflow_dispatch`
+On a tag push, `github.event.inputs.release_tag` evaluates to null and `format('refs/tags/{0}', null)`
+would produce a bare `refs/tags/`. The `github.event_name == 'workflow_dispatch' && ... || ...` ternary
+short-circuits before `format` runs, which is why the existing lines 33/128/151 use exactly this shape.
+Reuse it rather than inventing a new expression. [VERIFIED: pattern already in-repo and shipping]
+
+### 3. A malformed `release_tag` will now hard-fail (intended)
+If someone types `refs/tags/v0.3.6` into the input, `EXPECTED_REF` becomes
+`refs/tags/refs/tags/v0.3.6` and the guard fails even on a correct tag dispatch. That is the desired
+fail-loud behavior — but note the same malformed input already breaks the checkout at line 33 and the
+artifact naming at line 238, so the guard just surfaces it earlier. Do not add normalization/sanitization
+logic; that is scope creep beyond the locked decision.
+
+### 4. Tag dispatch runs the workflow file *as it exists at that tag*
+This is the caveat issue #100 flags, and it has a benign consequence worth knowing:
+- Backfilling an **old** tag by dispatching on that tag runs the old `release.yml`, which has no guard —
+  but `workflow_ref` is already `refs/tags/<v>`, so the identity is correct anyway. Verified that
+  `v0.3.3`, `v0.3.4`, `v0.3.5` all carry a `workflow_dispatch` trigger with the `release_tag` input, so
+  this path works today. [VERIFIED: git show <tag>:.github/workflows/release.yml]
+- Backfilling an old tag by dispatching from `main` runs the new guarded file → correctly blocked.
+
+### 5. Tag dispatch also changes which `scripts/` version runs (pre-existing, not new)
+The `publish-release` checkout at line 200-201 has **no** `ref:`, so it checks out `github.ref`. Under
+tag dispatch that is the tag, meaning `scripts/build_releases_index.sh` (invoked at line 351) comes from
+the tag rather than from `main`. This was already the behavior for every normal tag-push release; only
+the dispatch-from-`main` path was the anomaly. Verified the script exists at `v0.3.3`/`v0.3.4`/`v0.3.5`
+and its CLI (`--existing --output --project --version --date --max`) is unchanged since `v0.3.1`
+(single commit `0ddd5fc`). No action needed. [VERIFIED: git cat-file -e + git log]
+
+### 6. Re-runs preserve the original ref
+Re-running a failed run reuses the triggering event's ref, so `github.workflow_ref` does not silently
+become `refs/heads/main` on a re-run of a tag-based run. A re-run of a *main-dispatched* run will keep
+failing the guard, which is correct. [ASSUMED: standard re-run semantics; not separately verified]
+
+### 7. The guard's premise breaks under `workflow_call`
+The SAN comes from `job_workflow_ref`, and there is no `github.job_workflow_ref` expression to compare
+against. While signing stays inline in `release.yml` the two claims are equal. The inline comment in the
+proposed snippet records this so a future reusable-workflow refactor does not silently defeat the guard.
+[VERIFIED: fulcio oid-info.md + absence of the context property]
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Extracting the ref from `workflow_ref` | `awk -F@`, `cut`, `sed`, regex | `${WORKFLOW_REF##*@}` | Pure bash, no subprocess, shellcheck-clean, no quoting hazards |
+| Computing "the ref that was built" | New bespoke expression | Copy the ternary from line 33 verbatim | Guarantees the guard and the checkout can never disagree |
+| Failing the job | `exit 1` bare | `::error title=...::` + `exit 1` | Surfaces the reason as a run-summary annotation |
+| Overriding the signing ref | Any attempt to force `refs/tags/...` into the cert | Nothing — it is not possible | Identity comes from the OIDC token, not from workflow-controlled values |
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | `actionlint` v1.7.11 + `yq` v4.53.3 + `shellcheck` (all locally installed) |
+| Config file | none needed |
+| Quick run command | `actionlint .github/workflows/release.yml` |
+| Full suite command | `actionlint .github/workflows/*.yml && yq '.jobs.publish-release.steps \| map(.name)' .github/workflows/release.yml` |
+
+### Requirements → Test Map
+| Behavior | Test Type | Command | Exists? |
+|----------|-----------|---------|---------|
+| Workflow still valid YAML/Actions syntax | static | `actionlint .github/workflows/release.yml` | yes |
+| Guard step lands before signing | static | `yq '.jobs.publish-release.steps \| map(.name)' .github/workflows/release.yml` | yes |
+| Guard bash is lint-clean | static | extract `run:` body → `shellcheck -s bash -` | yes |
+| Guard fails on ref mismatch | behavioral (local) | run the `run:` body with `WORKFLOW_REF=...@refs/heads/main EXPECTED_REF=refs/tags/vX`; expect exit 1 | yes (Case A above) |
+| Guard passes on tag dispatch / tag push | behavioral (local) | same with matching refs; expect exit 0 | yes (Cases B/C above) |
+| End-to-end identity is `@refs/tags/<v>` | manual, post-merge | next real release; then `cosign verify-blob --certificate-identity .../release.yml@refs/tags/<v>` | manual-only — requires a real tag + OIDC |
+
+### Wave 0 Gaps
+None — all static and behavioral checks are runnable with tooling already installed. Only the end-to-end
+identity assertion is manual-only, and it is inherently deferred to the next release.
+
+## Project Constraints (from CLAUDE.md)
+
+- Conventional commits (`fix(ci): ...` / `build(ci): ...`).
+- No "Generated with Claude Code" trailers in commits, PRs, or issues.
+- No push to `main` without a PR.
+- Keep comments minimal and non-verbose — the one comment block justifying the guard is warranted because
+  the *reason* (identity comes from `workflow_ref`, not the checkout) is not inferable from the code.
+- **Use `yq` for validating YAML files** — satisfied above.
+- Do exactly what is asked; no unrequested refactoring of `release.yml`.
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|------------|-----------|---------|----------|
+| `actionlint` | workflow validation | yes | v1.7.11 | — |
+| `yq` | YAML validation (CLAUDE.md mandate) | yes | v4.53.3 | — |
+| `shellcheck` | guard bash lint | yes | installed | — |
+| `gh` | issue/run inspection, dispatch remediation | yes | 2.96.0 | — |
+| `cosign` | manual post-release identity verify | yes | installed (`cosign version`) | — |
+
+No missing dependencies.
+
+## Security Domain
+
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|-----------------|
+| V5 Input Validation | yes | `release_tag` reaches the shell only via `env:` — no `${{ }}` interpolation inside `run:` |
+| V6 Cryptography | yes | cosign keyless / Sigstore only; the change adds no crypto logic |
+| V4 Access Control | indirect | the guard tightens what identities downstream consumers must trust |
+
+| Pattern | STRIDE | Mitigation |
+|---------|--------|-----------|
+| Script injection via `workflow_dispatch` input | Tampering / EoP | pass through `env:`, quote all expansions |
+| Signing-identity spoof-by-drift (this bug) | Spoofing | the guard itself — refuse to sign when identity ≠ built ref |
+| Trust-boundary erosion via growing allowlist | Spoofing | fixing the root cause lets downstream retire the `v0.3.4`/`v0.3.5` exceptions |
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | Re-runs preserve the triggering event's ref, so `workflow_ref` is stable across re-runs | Gotcha 6 | Low — a drifting re-run ref would fail the guard (fail-safe direction), not silently mis-sign |
+
+## Open Questions
+
+1. **Fail-fast placement vs. locked placement**
+   - Known: `publish-release` runs only after both build jobs finish, so guarding there wastes the full
+     matrix build time on a bad invocation (~10-20 min of runner minutes).
+   - Unclear: whether that waste is worth duplicating the guard into `build-artifacts` and
+     `build-java-artifacts`.
+   - Recommendation: ship the single guard as decided. The failure is loud and cheap to retry; two extra
+     copies of the same bash violate "radically simple" for no correctness gain.
+
+2. **Whether to document the tag-dispatch invocation in the repo**
+   - Known: the guard's error message already prints the correct `gh workflow run ... --ref <tag>` command.
+   - Unclear: whether a `RELEASING.md` / README note is also wanted.
+   - Recommendation: out of scope — CONTEXT explicitly rejects docs-only fixes, and the error message is
+     the point-of-need documentation. Raise separately if desired.
+
+## Sources
+
+### Primary (HIGH confidence)
+- docs.github.com/en/actions/reference/workflows-and-actions/contexts — `github.workflow_ref` format, `github.ref`, `github.ref_name`
+- docs.github.com/en/actions/reference/security/oidc — `workflow_ref` vs `job_workflow_ref` claim definitions
+- github.com/sigstore/fulcio/blob/main/docs/oid-info.md — SAN/Build Signer URI = `server_url + job_workflow_ref`; `.1.5`/`.1.6` deprecated
+- docs.github.com/en/rest/actions/workflows — dispatch `ref` accepts a branch **or tag** name
+- Local repo evidence: `gh run list --workflow=release.yml` (run 22517529944 = tag dispatch on `v0.3.0`), `git show v0.3.0:.github/workflows/release.yml:109`, `git show v0.3.{3,4,5}:.github/workflows/release.yml`, `gh issue view 100` (decoded `v0.3.5` cert)
+- Local validation: `actionlint` / `yq` / `shellcheck` runs on the candidate patch
+
+### Secondary (MEDIUM confidence)
+- sigstore/cosign discussion #2936 — certificate identity for reusable-workflow keyless signing (context for why `workflow_call` is a trap)
+
+### Tertiary (LOW confidence — not relied upon)
+- community discussion #75513 claiming dispatch accepts branches only. **Contradicted** by the official
+  REST docs and by this repo's own `v0.3.0` tag dispatch. Disregarded.
+
+## Metadata
+
+**Confidence breakdown:**
+- Root cause: HIGH — official docs plus a decoded certificate plus in-repo run history all agree
+- Fix mechanism: HIGH — candidate patch written and validated with actionlint/yq/shellcheck and 4 behavioral cases
+- Gotchas: HIGH except A1 (re-run semantics, ASSUMED, fail-safe direction)
+
+**Research date:** 2026-07-30
+**Valid until:** 2026-08-29 (GitHub Actions contexts and Fulcio OID mapping are stable surfaces)

--- a/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-REVIEW.md
+++ b/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-REVIEW.md
@@ -1,0 +1,135 @@
+---
+phase: quick/260730-ggr
+reviewed: 2026-07-30T09:30:50Z
+depth: quick
+files_reviewed: 1
+files_reviewed_list:
+  - .github/workflows/release.yml
+findings:
+  critical: 1
+  warning: 6
+  info: 1
+  total: 8
+status: issues_found
+---
+
+# Quick Task 260730-ggr: Code Review Report
+
+**Reviewed:** 2026-07-30T09:30:50Z
+**Depth:** quick
+**Files Reviewed:** 1
+**Status:** issues_found
+
+## Summary
+
+Reviewed the single changed file `.github/workflows/release.yml` (+25 lines, commit `52ea354`), focusing on the new `Verify signing identity matches released ref` guard in `publish-release`.
+
+The guard is correctly placed (before `Install cosign`, so nothing is signed, uploaded to R2, or published on failure), uses `env:` rather than `${{ }}` interpolation inside `run:` (no direct shell-injection sink), and does hard-fail the exact scenario from issue #100 (dispatch from `main` with a tag input). `actionlint .github/workflows/release.yml` is clean. So the happy path and the reported-bug path both behave as intended.
+
+However, the comparison logic is **bypassable**. `SIGNING_REF="${WORKFLOW_REF##*@}"` uses greedy suffix stripping on a value whose ref component may itself contain `@` — a legal git ref character. I confirmed empirically that git accepts a branch named `hotfix@refs/tags/v0.3.6` (`git check-ref-format --branch` passes) and that the guard exits **0** for `WORKFLOW_REF=.../release.yml@refs/heads/hotfix@refs/tags/v0.3.6` with `EXPECTED_REF=refs/tags/v0.3.6` — i.e. artifacts get signed with a `refs/heads/...` identity while the guard reports a match. That is the precise failure mode the step exists to prevent, so it is a BLOCKER for a control whose only job is to be unbypassable.
+
+Two further structural weaknesses: the guard compares only the *ref* suffix, never the repository or workflow-file path that also form the cosign SAN; and `EXPECTED_REF` is a third independent copy of the checkout ternary. Note that the SUMMARY's claim that the guard and the checkout "cannot drift" / "can never silently drift apart" is not supported by the implementation — they are two unlinked string literals in different jobs, verified equal once by hand at commit time. Both are fixed by the same rewrite proposed in CR-01/WR-01/WR-02.
+
+## Critical Issues
+
+### CR-01: Greedy `##*@` parse lets a ref name containing `@` bypass the signing-identity guard
+
+**File:** `.github/workflows/release.yml:271-272`
+**Issue:** `SIGNING_REF="${WORKFLOW_REF##*@}"` strips through the **last** `@` in `github.workflow_ref`. Git ref names may legally contain `@` (only a bare `@` and the sequence `@{` are rejected — verified with `git check-ref-format --branch 'hotfix@refs/tags/v0.3.6'` → exit 0). Two consequences, both proven by running the committed script verbatim:
+
+1. **Guard bypass (fail-open).** Dispatching from a branch named `hotfix@refs/tags/v0.3.6` with `release_tag=v0.3.6` yields
+   `WORKFLOW_REF=amikos-tech/chroma-go-local/.github/workflows/release.yml@refs/heads/hotfix@refs/tags/v0.3.6`.
+   `${WORKFLOW_REF##*@}` → `refs/tags/v0.3.6`, which equals `EXPECTED_REF`, so the guard prints
+   `Signing identity ref refs/tags/v0.3.6 matches released ref refs/tags/v0.3.6.` and exits **0** — while cosign then signs with SAN `.../release.yml@refs/heads/hotfix@refs/tags/v0.3.6`. Artifacts are signed, pushed to R2 and attached to the GitHub release under a branch identity: issue #100 reproduced *through* the guard. The same trick works with a tag named `x@refs/tags/v0.3.6`. This is reachable by anyone who can create a branch and dispatch the workflow, including an operator deliberately working around the guard.
+2. **False positive (fail-closed).** A legitimate tag containing `@` (e.g. `v1.0.0@beta`, matched by the `v*` trigger) truncates to `beta` and hard-fails a valid tag-push release with a misleading message: `signed as release.yml@beta but were built from refs/tags/v1.0.0@beta`.
+
+**Fix:** Drop the substring parse entirely and compare the **full** identity string, which also closes WR-01. `github.repository` and the workflow path are fixed, known values, so an exact comparison has no parsing edge cases:
+
+```yaml
+      - name: Verify signing identity matches released ref
+        shell: bash
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          EXPECTED_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/release.yml@${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.release_tag) || github.ref }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "${WORKFLOW_REF}" != "${EXPECTED_WORKFLOW_REF}" ]; then
+            printf '::error title=Signing identity mismatch::Artifacts would be signed as %s but must be %s\n' \
+              "${WORKFLOW_REF}" "${EXPECTED_WORKFLOW_REF}"
+            printf 'Refusing to sign: the cosign certificate identity must match the released ref (see issue #100).\n'
+            printf 'Re-run the release from the tag itself:\n'
+            printf '  gh workflow run release.yml --ref %q -f release_tag=%q\n' "${RELEASE_TAG}" "${RELEASE_TAG}"
+            exit 1
+          fi
+          printf 'Signing identity %s matches the released ref.\n' "${WORKFLOW_REF}"
+```
+
+If the suffix-only comparison is kept for some reason, at minimum use non-greedy `${WORKFLOW_REF#*@}` (first `@`) — verified to return the full `refs/heads/hotfix@refs/tags/v0.3.6` and therefore to fail closed on the bypass input.
+
+## Warnings
+
+### WR-01: Guard validates only the ref, not the repository or workflow-file path that also form the cosign identity
+
+**File:** `.github/workflows/release.yml:271-279`
+**Issue:** The cosign `--certificate-identity` built at lines 294 / 384 is `https://github.com/${WORKFLOW_REF}` — repo **plus** path **plus** ref. The guard checks only the ref component, so it passes for identities downstream consumers will still reject. Verified: `WORKFLOW_REF=attacker/fork/.github/workflows/other.yml@refs/tags/v0.3.6` with `EXPECTED_REF=refs/tags/v0.3.6` exits **0**. Renaming/moving `release.yml`, or a fork running the release job, silently produces a brand-new identity — exactly the "downstream must widen the allowlist" outcome the issue's acceptance criteria set out to end. The error message compounds this by hardcoding the string `release.yml@` (see IN-01) even though the real path is never inspected.
+**Fix:** Use the full-identity comparison in CR-01, which pins repo, path, and ref in one exact string match.
+
+### WR-02: `EXPECTED_REF` is a third unenforced copy of the checkout ternary — drift silently invalidates the guard
+
+**File:** `.github/workflows/release.yml:267` (copies at `:33`, `:128`; bare-tag variants at `:151`, `:219`, `:268`, `:338`, `:429`)
+**Issue:** The guard's correctness rests entirely on `EXPECTED_REF` at line 267 being identical to the `actions/checkout` `ref:` at lines 33 and 128. Nothing enforces that — they are independent literals in different jobs. If the build-job checkout expression is ever changed (e.g. to support a new dispatch input) and line 267 is not, the guard compares against a ref that was not built and passes anyway: a silent fail-open in a supply-chain control. The expression now appears 8 times in the file in two variants.
+**Fix:** Hoist to workflow-level `env` (the `env` context is available in `jobs.<id>.steps[*].with`) so one definition feeds every consumer:
+
+```yaml
+env:
+  RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.release_tag) || github.ref }}
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+```
+
+then `ref: ${{ env.RELEASE_REF }}` in both checkouts and `EXPECTED_REF: ${{ env.RELEASE_REF }}` in the guard.
+
+### WR-03: Guard runs after the untrusted `release_tag` has already driven filesystem writes and checksums
+
+**File:** `.github/workflows/release.yml:263` (relative to `:216-254`)
+**Issue:** The guard is step 6 of `publish-release`, after `Normalize artifact names` has already used the free-form input in `mv "${f}" "${PROJECT}-${TAG}-${os}-${arch}.tar.gz"` (line 238) and after `Build checksum manifest`. A `release_tag` containing `/` or `..` therefore reaches a rename target before any validation; nothing is published (the guard aborts, and the build jobs' `checkout` of a nonexistent ref usually fails first), but the ordering means the only validation in the workflow sits downstream of the sinks it should protect. It also means the failure only surfaces after the 3-OS matrix and the Java build have completed.
+**Fix:** Make the guard the **first** step of `publish-release` (immediately after `Checkout repository scripts`, before any artifact download). Better still, extract it into a tiny `preflight` job that `build-artifacts` and `build-java-artifacts` both `needs:`, so a mis-dispatched release fails in seconds instead of red-lining a full build.
+
+### WR-04: `release_tag` is never format-validated, and reaches `::error` annotations unsanitized (workflow-command injection into the run log)
+
+**File:** `.github/workflows/release.yml:268, 273-276`
+**Issue:** `release_tag` is a free-form `type: string` input with no pattern check anywhere in the workflow. It is echoed into a workflow command: `echo "::error title=...::... but were built from ${EXPECTED_REF}"`. Verified: `EXPECTED_REF=$'refs/tags/v1\n::error::pwned'` causes the guard to emit a second, forged `::error::pwned` annotation. The same channel reaches `::stop-commands::` / `::add-mask::`, which can suppress or mask subsequent annotations — i.e. hide *other* steps' failures from whoever reviews the run. Privilege required (workflow dispatch) keeps this out of BLOCKER territory, but a log-integrity hole inside the step whose entire purpose is trustworthy release provenance is not acceptable.
+**Fix:** Validate the input before use, and emit with `printf`/`GITHUB_STEP_SUMMARY` rather than interpolating untrusted text into `::` commands:
+
+```bash
+case "${RELEASE_TAG}" in
+  v[0-9]*.[0-9]*.[0-9]*) ;;
+  *) echo "::error::release_tag must look like vMAJOR.MINOR.PATCH"; exit 1 ;;
+esac
+```
+
+### WR-05: Copy-pasteable remediation command interpolates untrusted input unquoted
+
+**File:** `.github/workflows/release.yml:276`
+**Issue:** `echo "  gh workflow run release.yml --ref ${RELEASE_TAG} -f release_tag=${RELEASE_TAG}"` prints a command the error text explicitly instructs an operator to run, built from an unvalidated dispatch input, with no quoting. `release_tag='v1; rm -rf ~'` renders as a runnable compound command on the operator's machine. The SUMMARY records that the plan specified `--ref "${RELEASE_TAG}"` and that the unquoted form was chosen because quoting is "cosmetic" — it is not; this is the one place the value is deliberately rendered for execution.
+**Fix:** `printf '  gh workflow run release.yml --ref %q -f release_tag=%q\n' "${RELEASE_TAG}" "${RELEASE_TAG}"` (as in CR-01), and pair it with the WR-04 input validation.
+
+### WR-06: The `workflow_dispatch` backfill path is now always-red, but its description, `if:` gate, and docs were not updated
+
+**File:** `.github/workflows/release.yml:7-12, 193, 275-276`
+**Issue:** Post-guard, dispatch is viable **only** from the tag ref — yet the input still advertises itself as `"Existing tag to release/backfill (for example v0.3.0)"`, and `if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'` (line 193) still admits dispatch from any branch. The result for the documented use case (backfill an old tag from `main`) is a guaranteed failing run after a full 3-OS matrix build, rather than a clear refusal. The printed remediation (`--ref <tag>`) also runs the workflow file **as it exists at that tag** — for pre-guard tags that is a different, unguarded workflow, so the advice does not deliver the guard's protection. Issue #100 called this out explicitly ("when the workflow at the tag is broken, releasing from `main` is the only way out without re-tagging — see #99"); the escape hatch is now closed with no replacement and no documentation of the new required procedure (no `docs/`, `README.md`, or `CHANGELOG.md` change accompanies the commit).
+**Fix:** (a) Update the input `description:` to state that the workflow must be dispatched with `--ref <the same tag>`; (b) narrow the gate to `if: startsWith(github.ref, 'refs/tags/')` so a branch dispatch is skipped/refused before any build burns CI; (c) add a short "Releasing" note to `README.md` or `CHANGELOG.md` recording the required invocation and what to do when the workflow at a tag is broken (cut a new patch tag from `main`).
+
+## Info
+
+### IN-01: Error message hardcodes `release.yml@`, which can drift from the real workflow path
+
+**File:** `.github/workflows/release.yml:273`
+**Issue:** `Artifacts would be signed as release.yml@${SIGNING_REF}` prints a literal filename that the guard never actually reads out of `WORKFLOW_REF`. If the workflow is renamed or moved, the message reports a path that is not the one in the certificate — misleading during exactly the incident this step exists to flag.
+**Fix:** Print the real value: `"${WORKFLOW_REF}"` (the CR-01 rewrite already does this).
+
+---
+
+_Reviewed: 2026-07-30T09:30:50Z_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: quick_

--- a/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-SUMMARY.md
+++ b/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-SUMMARY.md
@@ -1,0 +1,146 @@
+---
+phase: quick/260730-ggr
+plan: 01
+subsystem: infra
+tags: [github-actions, cosign, sigstore, oidc, supply-chain, release]
+
+# Dependency graph
+requires: []
+provides:
+  - "publish-release guard step 'Verify signing identity matches released ref' that hard-fails before cosign runs when github.workflow_ref's ref does not match the ref the artifacts were built from"
+  - "Fail-loud remediation path: ::error annotation naming both refs plus a copy-pasteable `gh workflow run release.yml --ref <tag> -f release_tag=<tag>`"
+  - "Closes the dispatch-from-main backfill escape hatch that produced release.yml@refs/heads/main signing identities"
+affects: [release, supply-chain-verification, chroma-go-consumer-allowlist]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Signing-identity precondition guard: compare ${WORKFLOW_REF##*@} against the same actions/checkout ref ternary, so guard and checkout cannot drift"
+    - "Untrusted workflow_dispatch inputs reach the shell only via env:, never inlined into run:"
+
+key-files:
+  created: []
+  modified:
+    - .github/workflows/release.yml
+
+key-decisions:
+  - "Guard placed immediately before 'Install cosign' rather than duplicated into the build jobs — one non-zero exit skips signing, R2 upload, CDN purge and release publish, so a single copy is sufficient (radically simple)"
+  - "EXPECTED_REF reuses the checkout ternary from build-artifacts verbatim instead of a reimplementation, guaranteeing the guard compares against literally the ref that was built"
+  - "No normalization/sanitization of a malformed release_tag — failing loud is the intended behavior (RESEARCH Gotcha 3)"
+  - "Comment block retained to record why the guard exists (identity comes from workflow_ref, not the checkout) and that the premise holds only while signing stays inline in this file"
+
+patterns-established:
+  - "Precondition guards for supply-chain steps: verify the OIDC-derived identity matches the built ref before any artifact is signed or published"
+
+requirements-completed: [ISSUE-100]
+
+# Metrics
+duration: 3min
+completed: 2026-07-30
+---
+
+# Quick Task 260730-ggr: Fix issue #100 (release workflow signs with wrong ref identity) Summary
+
+**`release.yml` now refuses to sign when the cosign keyless identity would not match the released ref — a 25-line `publish-release` guard comparing `${WORKFLOW_REF##*@}` against the build's checkout ternary, verified against a 4-case exit-code matrix.**
+
+## Performance
+
+- **Duration:** 3 min
+- **Started:** 2026-07-30T09:21:27Z
+- **Completed:** 2026-07-30T09:24:10Z
+- **Tasks:** 2 (1 code, 1 verification-only)
+- **Files modified:** 1
+
+## Accomplishments
+
+- Added the step `Verify signing identity matches released ref` to `publish-release`, positioned between `Build checksum manifest` (5) and `Install cosign` (7). A non-zero exit there skips signing, R2 upload, CDN purge and the GitHub release publish — so no artifact can be signed or shipped with a mismatched identity.
+- The guard derives the signing ref as `${WORKFLOW_REF##*@}` from `github.workflow_ref` (the value cosign actually turns into the certificate SAN) and compares it to `EXPECTED_REF`, which is byte-identical to the `actions/checkout` ternary in `build-artifacts`. Verified equal programmatically, so the two can never silently drift apart.
+- On mismatch it emits `::error title=Signing identity mismatch::` naming both refs, references issue #100, and prints the tag-substituted `gh workflow run release.yml --ref v0.3.6 -f release_tag=v0.3.6` remediation, so an operator hitting this in CI is not left guessing.
+- Proved the full exit-code matrix against the script extracted from the committed YAML (not a re-typed copy): dispatch-from-main = 1, tag-dispatch = 0, tag-push = 0, mismatched-input = 1.
+- Confirmed zero `${{ }}` interpolation inside the `run:` body — the free-form `release_tag` input reaches bash only through `env:`, closing the script-injection sink (T-ggr-02).
+
+## Task Commits
+
+1. **Task 1: Insert the signing-identity guard into publish-release** — `52ea354` (fix)
+2. **Task 2: Prove the guard's exit-code matrix locally** — no commit (verification-only task; the plan specifies read-only, "Write no new files", and no test script is committed)
+3. **Follow-up: Close code-review bypass** — `4a5d7aa` (fix), see below
+
+**Plan metadata:** handled by the orchestrator's docs commit.
+
+## Follow-up fix: guard bypass closed (post-review)
+
+The auto code-review (`260730-ggr-REVIEW.md`) found the `52ea354` guard bypassable: `SIGNING_REF="${WORKFLOW_REF##*@}"` strips through the *last* `@`, and git ref/branch names may legally contain `@`. A branch named e.g. `hotfix@refs/tags/v0.3.6` made the guard compare equal and exit 0 — reproducing issue #100 straight through the new guard.
+
+Commit `4a5d7aa` replaces the suffix-parse comparison with a full cosign-SAN-identity comparison (`env.EXPECTED_WORKFLOW_REF` = `github.repository`/`.github/workflows/release.yml@`+ref, matched against `github.workflow_ref` verbatim — no substring parsing at all), and hoists the checkout ref ternary to a single workflow-level `env.RELEASE_REF` consumed by both `actions/checkout` steps and the guard (closing the "three independent copies" drift risk). This also closes the fork/renamed-workflow-path spoof (repo + workflow path are now checked, not just the ref).
+
+Re-verified with a 12-case matrix (bypass case, `@`-containing legitimate tag, fork/path spoofs, the original 4-case matrix) — all pass. See `260730-ggr-VERIFICATION.md` for the independent re-check against `HEAD`.
+
+Three review warnings (repo/path spoofing, duplicated `EXPECTED_REF`) were resolved by this fix; four remain open and out of scope for this task: WR-03 (guard step ordering vs. earlier filesystem-writing steps), WR-04 (`release_tag` not format-validated before reaching `::error::` annotations), WR-05 (unquoted remediation command in the printed error), WR-06 (backfill-from-branch dispatch path now permanently red; no docs update). Recommend a follow-up `[BUG]`/`[CLN]` issue for these.
+
+## Files Created/Modified
+
+- `.github/workflows/release.yml` — one new `shell: bash` step in `publish-release` (+25 lines, 0 deletions) with its justifying comment block. No other step, action SHA, or `if:` gate touched.
+
+## Verification Results
+
+| Check | Result |
+|-------|--------|
+| `actionlint .github/workflows/release.yml` | clean |
+| Step order (`yq`, CLAUDE.md YAML mandate) | `Build checksum manifest`=5 < guard=6 < `Install cosign`=7 |
+| Guard bash under `shellcheck -s bash` | clean |
+| `${{` occurrences inside guard `run:` | 0 |
+| `WORKFLOW_REF` sourced from `github.workflow_ref` | yes |
+| `EXPECTED_REF` vs `build-artifacts` checkout `ref` | byte-identical |
+| Case A — dispatch from `main`, `release_tag=v0.3.6` | **exit 1** + annotation + remediation |
+| Case B — dispatch from tag `v0.3.6` | exit 0 |
+| Case C — tag push `v0.3.6` | exit 0 |
+| Case D — dispatched on `v0.3.6`, `release_tag=v0.3.5` | **exit 1** |
+| `git diff --stat` vs base | exactly 1 file, additive only, no new files |
+
+Threat register dispositions from the plan are satisfied: T-ggr-01 (mitigated by the guard itself), T-ggr-02 (`env:`-only input, all expansions quoted), T-ggr-03 (root cause fixed, downstream allowlist can stop growing), T-ggr-04 (accepted; recorded in the step's inline comment), T-ggr-SC (n/a — no package installs, all action SHAs unmodified).
+
+## Decisions Made
+
+None beyond the plan — the guard was inserted verbatim from RESEARCH.md "Proposed Guard Step (validated)" as the plan instructed ("an insertion, not a redesign"). The plan's Task 1 prose showed the remediation line with inner quotes (`--ref "${RELEASE_TAG}"`) while RESEARCH.md showed it unquoted; RESEARCH.md was followed since the plan directs verbatim copying twice, and the printed value is a bare tag name where quoting is cosmetic. Both forms satisfy the plan's verification greps.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+`actionlint .github/workflows/*.yml` (the plan's full-suite command) exits non-zero, but solely from a **pre-existing, unrelated** finding in `.github/workflows/ci.yml:313` (`SC2129` style: consider grouping redirects). Confirmed out of scope two ways: `ci.yml` is byte-identical to the plan base commit, and the same warning reproduces when linting the base version of that file in isolation. Per the executor scope boundary it was **not** fixed; logged to `deferred-items.md` with a suggested `[CLN]` follow-up. `release.yml` itself — the only file this plan changed — is `actionlint` clean.
+
+## Deferred / Manual Follow-up
+
+- **Post-merge, manual (inherently un-automatable pre-merge):** end-to-end identity confirmation needs a real tag plus live OIDC. On the next release, run `cosign verify-blob --bundle <artifact>.sigstore.json --certificate-identity "https://github.com/amikos-tech/chroma-go-local/.github/workflows/release.yml@refs/tags/<version>" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --use-signed-timestamps <artifact>` and confirm it passes with no allowlist widening.
+- Once a guarded release ships cleanly, the downstream chroma-go `v0.3.4`/`v0.3.5` identity-allowlist exceptions can be retired (T-ggr-03).
+- Releases must now be started on the tag ref (`gh workflow run release.yml --ref <tag> -f release_tag=<tag>`); dispatching from `main` is intentionally blocked. Note that backfilling an **old** tag by dispatching on that tag runs the pre-guard workflow file, where the identity is already correct anyway.
+
+## User Setup Required
+
+None - no external service configuration required. No new secrets, permissions, or inputs.
+
+## Next Phase Readiness
+
+- Change is additive, statically verified, and behaviorally proven; ready for PR. Per CLAUDE.md this must be delivered via PR — not pushed straight to `main`.
+- No follow-on code work required; the remaining item is the post-release manual `cosign verify-blob` confirmation above.
+
+## Self-Check: PASSED
+
+| Claim | Result |
+|-------|--------|
+| `.github/workflows/release.yml` exists and contains the guard step at HEAD | FOUND (verified via `git show HEAD:...`) |
+| Commit `52ea354` exists | FOUND (`52ea354845f99203ea8cb2b4e195544f63b9fbd0`) |
+| `260730-ggr-SUMMARY.md` exists | FOUND |
+| `deferred-items.md` exists | FOUND |
+| Diff vs base is 1 file, +25/-0 | CONFIRMED (`1 file changed, 25 insertions(+)`) |
+
+No missing items. (An initial self-check script reported a false negative on the commit lookup
+because `set -o pipefail` combined with `grep -q`'s early exit turns `git log`'s SIGPIPE into a
+non-zero pipeline status; re-verified without `pipefail` and via `git rev-parse`.)
+
+---
+*Phase: quick/260730-ggr*
+*Completed: 2026-07-30*

--- a/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-VERIFICATION.md
+++ b/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-VERIFICATION.md
@@ -1,0 +1,87 @@
+---
+phase: quick/260730-ggr
+verified: 2026-07-30T14:00:00Z
+status: passed
+score: 9/9 must-haves verified
+overrides_applied: 0
+---
+
+# Quick Task 260730-ggr: Fix issue #100 (release signing identity) Verification Report
+
+**Task Goal:** Fix issue #100 — release workflow signs with `refs/heads/main` identity instead of `refs/tags/<version>` when dispatched from `main`. The final delivered guard must compare the FULL cosign SAN identity (repo + workflow path + ref, via `EXPECTED_WORKFLOW_REF` built from `github.repository` and `env.RELEASE_REF`) against `github.workflow_ref`, not just a parsed ref suffix — this hardening was added in follow-up commit `4a5d7aa` after the initial guard (`52ea354`) was found bypassable during code review.
+
+**Verified:** 2026-07-30T14:00:00Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Important Finding: SUMMARY.md Is Stale
+
+`260730-ggr-SUMMARY.md` documents only commit `52ea354` — the **original, bypassable** guard (`SIGNING_REF="${WORKFLOW_REF##*@}"` compared against `EXPECTED_REF`). It does not mention the follow-up commit `4a5d7aa` ("close signing-identity guard bypass and consolidate expected-ref") at all, even though `4a5d7aa` is already on `main` and is what actually ships. The SUMMARY's line "Verified equal programmatically, so the two can never silently drift apart" describes the *old*, now-superseded mechanism.
+
+This verification did **not** trust SUMMARY.md. It re-derived the guard script directly from the committed `release.yml` at `HEAD` (which is commit `4a5d7aa`, one commit ahead of what SUMMARY.md describes) and re-ran the review's own bypass proof against it.
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | Guard hard-fails before signing when `workflow_ref`'s ref differs from the built ref | VERIFIED | Live re-run of guard script extracted via `yq` from `release.yml`@HEAD: dispatch-from-main case exits 1 with correct `::error` annotation |
+| 2 | Guard passes unchanged for tag push and dispatch-on-tag | VERIFIED | Re-run: tag-dispatch and tag-push cases both exit 0 |
+| 3 | Mismatch output names both refs + prints `gh workflow run release.yml --ref <tag> -f release_tag=<tag>` remediation | VERIFIED | Captured stdout: `::error title=Signing identity mismatch::Artifacts would be signed as ... but must be ...` followed by `gh workflow run release.yml --ref v0.3.6 -f release_tag=v0.3.6` |
+| 4 | No artifact is signed/uploaded/published when guard fails | VERIFIED | `yq` step-order dump: guard is step 6, immediately before `Install cosign` (7), `Sign and verify artifacts` (8), `Upload artifacts to R2` (9), `Publish GitHub release` (11); non-zero exit under `set -euo pipefail` in a GH Actions job with no `continue-on-error` skips all subsequent steps |
+| 5 | `release.yml` is `actionlint` clean; guard bash is `shellcheck` clean | VERIFIED | `actionlint .github/workflows/release.yml` exit 0; guard `run:` body piped through `shellcheck -s bash -` exit 0 |
+| 6 | **Critical bypass (CR-01) closed**: a branch/ref name containing `@` can no longer spoof a match | VERIFIED | Reproduced REVIEW.md's exact proof-of-bypass input (`.../release.yml@refs/heads/hotfix@refs/tags/v0.3.6` vs `EXPECTED=.../release.yml@refs/tags/v0.3.6`) against the **current** guard script — now exits **1** (was 0 against the pre-fix `52ea354` guard per REVIEW.md) |
+| 7 | Guard validates full identity (repo + workflow path + ref), not just ref suffix (WR-01 closed) | VERIFIED | Reproduced REVIEW.md's fork/path-spoof input (`attacker/fork/.github/workflows/other.yml@refs/tags/v0.3.6` vs the real repo/path/ref) — exits **1**. Legitimate tag containing `@` (`v1.0.0@beta`) with matching full identity now correctly exits **0** (WR-01's flagged false-positive case also resolved as a side effect) |
+| 8 | `EXPECTED_WORKFLOW_REF`/`RELEASE_REF` is a single source of truth, not independently re-typed (WR-02 closed) | VERIFIED | Workflow-level `env.RELEASE_REF` ternary appears exactly **once** in the file (line 21); both `actions/checkout` steps (`build-artifacts`, `build-java-artifacts`) and the guard's `EXPECTED_WORKFLOW_REF` all reference `${{ env.RELEASE_REF }}` — no independent copies of the ternary remain (`grep -c "format('refs/tags/{0}'"` → 1 occurrence total) |
+| 9 | No unresolved debt markers (TBD/FIXME/XXX/TODO/HACK/PLACEHOLDER) in the changed file | VERIFIED | `grep -iE "TBD|FIXME|XXX|TODO|HACK|PLACEHOLDER" .github/workflows/release.yml` → no matches |
+
+**Score:** 9/9 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `.github/workflows/release.yml` | Contains `Verify signing identity matches released ref` step between `Build checksum manifest` and `Install cosign`, using full-identity comparison | VERIFIED | Step present at position 6 of 11 in `publish-release`; `env.EXPECTED_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/release.yml@${{ env.RELEASE_REF }}` compared verbatim (`!=`) against `env.WORKFLOW_REF: ${{ github.workflow_ref }}` |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|-----|-----|--------|---------|
+| Guard step `env.WORKFLOW_REF` | `github.workflow_ref` context | `env:` block | WIRED | `grep` confirms `WORKFLOW_REF: ${{ github.workflow_ref }}`, no inlining into `run:` |
+| Guard step `env.EXPECTED_WORKFLOW_REF` | workflow-level `env.RELEASE_REF` + `github.repository` | `${{ env.RELEASE_REF }}` reuse | WIRED | Single definition at workflow-level `env:` (line 17-21), consumed by both checkout `ref:` fields and the guard — confirmed byte-identical reuse, zero drift risk |
+| Guard step position | `Install cosign` / `Sign and verify artifacts` / `Upload artifacts to R2` / `Publish GitHub release` | non-zero exit under `set -euo pipefail` skips subsequent job steps | WIRED | Step order confirmed via `yq`: guard (6) precedes all four signing/publish steps (7, 8, 9, 11) |
+
+### Behavioral Spot-Checks (Guard Exit-Code Matrix, Re-Run Independently)
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| Dispatch from `main` (issue #100 original bug) | guard script w/ `WORKFLOW_REF=.../release.yml@refs/heads/main`, `EXPECTED_WORKFLOW_REF=.../release.yml@refs/tags/v0.3.6` | exit 1 | PASS |
+| Dispatch from tag `v0.3.6` | matching full identities | exit 0 | PASS |
+| Tag push `v0.3.6` | matching full identities | exit 0 | PASS |
+| Dispatched on `v0.3.6`, `release_tag=v0.3.5` | mismatched | exit 1 | PASS |
+| **CR-01 bypass reproduction**: branch `hotfix@refs/tags/v0.3.6` | `WORKFLOW_REF=.../release.yml@refs/heads/hotfix@refs/tags/v0.3.6` vs `EXPECTED=.../release.yml@refs/tags/v0.3.6` | exit **1** (was 0 pre-fix per REVIEW.md) | PASS |
+| **WR-01 reproduction**: forked repo, renamed workflow file | `WORKFLOW_REF=attacker/fork/.github/workflows/other.yml@refs/tags/v0.3.6` vs real identity | exit 1 | PASS |
+| Legitimate tag containing `@` (`v1.0.0@beta`) | matching full identities | exit 0 (no more false-positive truncation) | PASS |
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| — | — | No TBD/FIXME/XXX/TODO/HACK/PLACEHOLDER in `release.yml` | — | none |
+| `260730-ggr-SUMMARY.md` | whole file | Documents pre-fix commit `52ea354` only; omits follow-up fix `4a5d7aa` that is what actually ships on `main` | INFO | Does not affect code correctness (verified independently against `HEAD`), but the task's own documentation trail is out of date and would mislead a future reader relying on SUMMARY.md alone |
+
+**Residual, pre-existing REVIEW.md warnings not addressed by this task (out of original task scope — not re-checked as blockers):** WR-03 (guard position relative to `Normalize artifact names`/checksum steps), WR-04 (unsanitized `::error` annotation injection via `release_tag`), WR-05 (unquoted `gh workflow run` remediation string), WR-06 (stale dispatch-input description / `if:` gate not narrowed). These were flagged as warnings (not the CRITICAL finding) in REVIEW.md and are unrelated to the specific verification ask (bypass closure + full-identity comparison); they remain open in the codebase as-is. Not treated as blockers here since the task's explicit goal was closing the CR-01 bypass, which is confirmed done.
+
+### Human Verification Required
+
+None. All checks in this task are statically/behaviorally verifiable via `actionlint`, `shellcheck`, `yq`, and direct extraction+execution of the guard's `run:` body. The one item that genuinely cannot be verified pre-merge — live OIDC/cosign identity confirmation on an actual tagged release — was already correctly flagged in PLAN.md/SUMMARY.md as deferred, post-merge, manual, and does not block this verification since the guard's *logic* has been proven directly.
+
+### Gaps Summary
+
+No gaps. All 9 must-haves verified against the actual committed file at `HEAD` (commit `4a5d7aa`), including live re-execution of the exact bypass string identified as CRITICAL in code review — confirmed closed, not merely claimed closed.
+
+---
+
+_Verified: 2026-07-30T14:00:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-deferred-items.md
+++ b/.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-deferred-items.md
@@ -1,0 +1,20 @@
+# Deferred Items — quick/260730-ggr
+
+Out-of-scope discoveries found while executing this plan. Not fixed here per the
+executor scope boundary (only issues directly caused by this task's changes are auto-fixed).
+
+## 1. Pre-existing shellcheck SC2129 in `.github/workflows/ci.yml`
+
+- **Found during:** plan-level verification (`actionlint .github/workflows/*.yml`)
+- **Detail:** `.github/workflows/ci.yml:313:9` — `SC2129:style:15:3: Consider using
+  { cmd1; cmd2; } >> file instead of individual redirects`
+- **Why deferred:** `ci.yml` is byte-identical to the plan base commit
+  (`git diff --name-only 5e5ded0 HEAD -- .github/workflows/ci.yml` is empty), and the same
+  warning reproduces when linting the base version of the file in isolation. It is unrelated
+  to the release-signing guard and is a style-only finding (no behavioral or security impact).
+- **Suggested follow-up:** separate `[CLN]` issue — group the `>> "$GITHUB_OUTPUT"` /
+  `>> "$GITHUB_STEP_SUMMARY"` redirects in that step into a single block.
+
+> Note: `actionlint .github/workflows/release.yml` (the file this plan changed) is clean.
+> The only `actionlint` non-zero exit across the workflow directory comes from this
+> pre-existing `ci.yml` finding.


### PR DESCRIPTION
## Summary
- Adds a fail-loud guard to `publish-release` in `release.yml` that hard-fails before cosign signing if the signing identity (from `github.workflow_ref`) doesn't match the ref the artifacts were actually built from — closing the gap where dispatching from `main` signed artifacts with a `refs/heads/main` identity instead of `refs/tags/<version>`.
- The guard compares the full cosign SAN identity (repo + workflow path + ref), not just a ref substring, after an initial version was found bypassable in code review via a crafted `@`-containing branch name.
- Consolidates the previously-duplicated checkout ref ternary into a single `env.RELEASE_REF`, shared by both checkout steps and the guard.

Fixes #100

## Test plan
- [x] `actionlint .github/workflows/release.yml` clean
- [x] `shellcheck -s bash` on the guard body clean
- [x] Exit-code matrix verified against the committed YAML (dispatch-from-main, tag-dispatch, tag-push, mismatched-input, bypass-attempt, `@`-containing legit tag, fork/path-spoof) — see `.planning/quick/260730-ggr-fix-issue-100-release-workflow-signs-wit/260730-ggr-VERIFICATION.md`
- [ ] Manual, post-merge: on the next real release, confirm `cosign verify-blob --certificate-identity ".../release.yml@refs/tags/<version>"` passes with no allowlist widening needed downstream