### PR TITLE
Protect published version tags from mutation

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -88,10 +88,11 @@ None yet.
 | 260731-fqz | Replace the ineffective yamllint apt path with a package-install-free, version-visible workflow lint contract and simplify Cloudflare cache purging into a structurally best-effort step | 2026-07-31 | 4174a8b | Verified — PR #107 | [260731-fqz-address-ci-lint-reproducibility-and-rele](./quick/260731-fqz-address-ci-lint-reproducibility-and-rele/) |
 | 260731-j64 | Address release purge diagnostics, lint documentation and Windows parity, resilient lint tool versions, and workflow lint hardening | 2026-07-31 | 4743852 | Needs Review — PR #107 | [260731-j64-address-release-purge-diagnostics-lint-d](./quick/260731-j64-address-release-purge-diagnostics-lint-d/) |
 | 260731-nkz | Validate and address release workflow review findings 1-10 | 2026-07-31 | f9d4e03 | Needs Review — PR #107 | [260731-nkz-validate-and-address-release-workflow-re](./quick/260731-nkz-validate-and-address-release-workflow-re/) |
+| 260731-sjq | Protect published `v*` tags from updates and deletions for issue #99 | 2026-07-31 | ruleset 20138470 | Verified | [260731-sjq-review-and-address-issue-99-by-protectin](./quick/260731-sjq-review-and-address-issue-99-by-protectin/) |
 
 ## Session Continuity
 
-Last activity: 2026-07-31 - Shipped quick tasks 260730-sz8 + 260731-dgm + 260731-eho + 260731-fqz + 260731-j64 + 260731-nkz as PR #107: fix silent CDN purge skip (issue #97), plus retry-timing bound and lint hardening. Human verification (hosted-release CDN purge observation) still pending post-merge.
+Last activity: 2026-07-31 - Completed quick task 260731-sjq: protected published `v*` tags from updates and deletions with verified repository ruleset 20138470 (issue #99).
 
 Last session: 2026-03-28T09:41:20Z
 Stopped at: Completed 10-02-PLAN.md

--- a/.planning/quick/260731-sjq-review-and-address-issue-99-by-protectin/260731-sjq-PLAN.md
+++ b/.planning/quick/260731-sjq-review-and-address-issue-99-by-protectin/260731-sjq-PLAN.md
@@ -49,7 +49,7 @@ Output: One verified repository-level tag ruleset. No source or workflow changes
 
 <interfaces>
 - Use the repository REST endpoint `repos/{owner}/{repo}/rulesets` through `gh api`; placeholders must resolve from the current checkout rather than hard-coding a repository name.
-- The current GitHub REST schema accepts `target: tag`, `enforcement: active`, `conditions.ref_name`, and the `update`, `deletion`, and `non_fast_forward` rule types. The `update` rule must set `parameters.update_allows_fetch_and_merge` to `false`.
+- The accepted GitHub tag-ruleset representation stores the exact rule objects `{type: "update"}`, `{type: "deletion"}`, and `{type: "non_fast_forward"}`. For a tag target, the `update` rule has no `parameters`; `update_allows_fetch_and_merge` is branch-only.
 - Creating a repository ruleset requires repository Administration write permission. The supplied live state says the current user has ADMIN permission, but execution must verify this before mutation.
 - `.github/workflows/release.yml` intentionally accepts existing tags through `workflow_dispatch` for retries and backfills. Do not add a sum.golang.org or other fail-on-existing-tag preflight: it would reject valid reruns and can race with first publication.
 </interfaces>
@@ -78,11 +78,11 @@ Output: One verified repository-level tag ruleset. No source or workflow changes
   <action>
 Run from the repository root. Confirm `gh auth status` succeeds and `gh api 'repos/{owner}/{repo}' --jq '.permissions.admin'` returns `true`; stop without mutation if not.
 
-Before any POST, list repository-owned tag rulesets with `GET repos/{owner}/{repo}/rulesets?includes_parents=false&amp;targets=tag&amp;per_page=100`, following pagination, then fetch each returned ruleset by ID so conditions, rules, enforcement, and bypass actors are available. Use the deterministic name `Protect published version tags`. Treat an existing ruleset as the desired no-op result only when it is active, targets tags, has `include: ["refs/tags/v*"]` and an empty exclude list, has no bypass actors, contains exactly the `update`, `deletion`, and `non_fast_forward` rule types, and the update rule has `update_allows_fetch_and_merge: false`.
+Before any POST, list repository-owned tag rulesets with `GET repos/{owner}/{repo}/rulesets?includes_parents=false&amp;targets=tag&amp;per_page=100`, following pagination, then fetch each returned ruleset by ID so conditions, rules, enforcement, and bypass actors are available. Use the deterministic name `Protect published version tags`. Treat an existing ruleset as the desired no-op result only when it is active, targets tags, has `include: ["refs/tags/v*"]` and an empty exclude list, has no bypass actors, contains exactly the `update`, `deletion`, and `non_fast_forward` rule types, and the update rule's `parameters` field is absent or null.
 
 If a non-equivalent ruleset has the deterministic name or overlaps `refs/tags/v*` through that exact include, `refs/tags/*`, or `~ALL`, stop before mutation and report its ID and full configuration. Do not create a duplicate, overwrite an existing ruleset, or delete anything. If one exact desired ruleset already exists, skip creation and continue to Task 2.
 
-When no candidate exists, submit one POST to `repos/{owner}/{repo}/rulesets` with the recommended GitHub media type and API version `2026-03-10`. Send a JSON body with name `Protect published version tags`, `target: "tag"`, `enforcement: "active"`, `bypass_actors: []`, `conditions.ref_name.include: ["refs/tags/v*"]`, `conditions.ref_name.exclude: []`, and rules `{type: "update", parameters: {update_allows_fetch_and_merge: false}}`, `{type: "deletion"}`, and `{type: "non_fast_forward"}`. Do not add a `creation` rule: new release tags must remain creatable. Capture the returned ruleset ID for diagnostics.
+When no candidate exists, submit one POST to `repos/{owner}/{repo}/rulesets` with the recommended GitHub media type and API version `2026-03-10`. Send a JSON body with name `Protect published version tags`, `target: "tag"`, `enforcement: "active"`, `bypass_actors: []`, `conditions.ref_name.include: ["refs/tags/v*"]`, `conditions.ref_name.exclude: []`, and the exact rules `{type: "update"}`, `{type: "deletion"}`, and `{type: "non_fast_forward"}`. Do not add parameters to the tag `update` rule. Do not add a `creation` rule: new release tags must remain creatable. Capture the returned ruleset ID for diagnostics.
 
 Do not edit `.github/workflows/release.yml`, query sum.golang.org, alter issue #99, or make any other repository-setting change. No PR is required for the remote ruleset; if later work introduces a PR, follow the repository's squash-merge-only rule.
   </action>
@@ -103,7 +103,7 @@ The authenticated administrator either creates exactly one desired ruleset or sa
   <name>Task 2: Verify the stored protection and unchanged release path</name>
   <files>.github/workflows/release.yml (read-only), remote repository ruleset (read-only)</files>
   <action>
-Re-read the repository-owned tag rulesets from GitHub after Task 1 and resolve the single ruleset named `Protect published version tags` to its full configuration. Verify the remote stored representation, not the request or Task 1 response: name, active enforcement, tag target, exact include/exclude conditions, empty bypass list, the three exact rule types, and `update_allows_fetch_and_merge: false` must all match. Also confirm no `creation` rule is present.
+Re-read the repository-owned tag rulesets from GitHub after Task 1 and resolve the single ruleset named `Protect published version tags` to its full configuration. Verify the remote stored representation, not the request or Task 1 response: name, active enforcement, tag target, exact include/exclude conditions, empty bypass list, the three exact rule types, and absent/null `parameters` on the `update` rule must all match. Also confirm no `creation` rule is present.
 
 Verify `.github/workflows/release.yml` is byte-for-byte unchanged from `HEAD`. Record in the quick-task summary that no sum.golang.org preflight was added because same-tag release retries/backfills are intentional and an existence lookup would both reject them and race first publication. Record the ruleset ID and HTML link returned by GitHub, but do not expose credentials or unrelated repository metadata.
 
@@ -124,7 +124,7 @@ jq -e --arg name "${name}" '
   .conditions.ref_name.exclude == [] and
   ((.bypass_actors // []) | length == 0) and
   (([.rules[].type] | sort) == ["deletion", "non_fast_forward", "update"]) and
-  ([.rules[] | select(.type == "update") | .parameters.update_allows_fetch_and_merge] == [false])
+  ([.rules[] | select(.type == "update") | (.parameters // null)] == [null])
 ' &lt;&lt;&lt;"${detail}" &gt;/dev/null
 git diff --exit-code HEAD -- .github/workflows/release.yml</automated>
   </verify>

--- a/.planning/quick/260731-sjq-review-and-address-issue-99-by-protectin/260731-sjq-PLAN.md
+++ b/.planning/quick/260731-sjq-review-and-address-issue-99-by-protectin/260731-sjq-PLAN.md
@@ -78,7 +78,7 @@ Output: One verified repository-level tag ruleset. No source or workflow changes
   <action>
 Run from the repository root. Confirm `gh auth status` succeeds and `gh api 'repos/{owner}/{repo}' --jq '.permissions.admin'` returns `true`; stop without mutation if not.
 
-Before any POST, list repository-owned tag rulesets with `GET repos/{owner}/{repo}/rulesets?includes_parents=false&amp;targets=tag&amp;per_page=100`, following pagination, then fetch each returned ruleset by ID so conditions, rules, enforcement, and bypass actors are available. Use the deterministic name `Protect published version tags`. Treat an existing ruleset as the desired no-op result only when it is active, targets tags, has `include: ["refs/tags/v*"]` and an empty exclude list, has no bypass actors, contains exactly the `update`, `deletion`, and `non_fast_forward` rule types, and the update rule's `parameters` field is absent or null.
+Before any POST, list repository-owned tag rulesets with `GET repos/{owner}/{repo}/rulesets?includes_parents=false&targets=tag&per_page=100`, following pagination, then fetch each returned ruleset by ID so conditions, rules, enforcement, and bypass actors are available. Use the deterministic name `Protect published version tags`. Treat an existing ruleset as the desired no-op result only when it is active, targets tags, has `include: ["refs/tags/v*"]` and an empty exclude list, has no bypass actors, contains exactly the `update`, `deletion`, and `non_fast_forward` rule types, and the update rule's `parameters` field is absent or null.
 
 If a non-equivalent ruleset has the deterministic name or overlaps `refs/tags/v*` through that exact include, `refs/tags/*`, or `~ALL`, stop before mutation and report its ID and full configuration. Do not create a duplicate, overwrite an existing ruleset, or delete anything. If one exact desired ruleset already exists, skip creation and continue to Task 2.
 
@@ -89,9 +89,9 @@ Do not edit `.github/workflows/release.yml`, query sum.golang.org, alter issue #
   <verify>
     <automated>set -euo pipefail
 name='Protect published version tags'
-pages="$(gh api 'repos/{owner}/{repo}/rulesets?includes_parents=false&amp;targets=tag&amp;per_page=100' --paginate --slurp)"
-test "$(jq --arg name "${name}" '[.[][] | select(.name == $name)] | length' &lt;&lt;&lt;"${pages}")" -eq 1
-id="$(jq -r --arg name "${name}" '.[][] | select(.name == $name) | .id' &lt;&lt;&lt;"${pages}")"
+pages="$(gh api 'repos/{owner}/{repo}/rulesets?includes_parents=false&targets=tag&per_page=100' --paginate --slurp)"
+test "$(jq --arg name "${name}" '[.[][] | select(.name == $name)] | length' <<<"${pages}")" -eq 1
+id="$(jq -r --arg name "${name}" '.[][] | select(.name == $name) | .id' <<<"${pages}")"
 gh api "repos/{owner}/{repo}/rulesets/${id}" --jq '.id' | grep -Eq '^[0-9]+$'</automated>
   </verify>
   <done>
@@ -112,9 +112,9 @@ Do not test enforcement by attempting to move or delete a live tag. Structural v
   <verify>
     <automated>set -euo pipefail
 name='Protect published version tags'
-pages="$(gh api 'repos/{owner}/{repo}/rulesets?includes_parents=false&amp;targets=tag&amp;per_page=100' --paginate --slurp)"
-test "$(jq --arg name "${name}" '[.[][] | select(.name == $name)] | length' &lt;&lt;&lt;"${pages}")" -eq 1
-id="$(jq -r --arg name "${name}" '.[][] | select(.name == $name) | .id' &lt;&lt;&lt;"${pages}")"
+pages="$(gh api 'repos/{owner}/{repo}/rulesets?includes_parents=false&targets=tag&per_page=100' --paginate --slurp)"
+test "$(jq --arg name "${name}" '[.[][] | select(.name == $name)] | length' <<<"${pages}")" -eq 1
+id="$(jq -r --arg name "${name}" '.[][] | select(.name == $name) | .id' <<<"${pages}")"
 detail="$(gh api "repos/{owner}/{repo}/rulesets/${id}")"
 jq -e --arg name "${name}" '
   .name == $name and
@@ -125,7 +125,7 @@ jq -e --arg name "${name}" '
   ((.bypass_actors // []) | length == 0) and
   (([.rules[].type] | sort) == ["deletion", "non_fast_forward", "update"]) and
   ([.rules[] | select(.type == "update") | (.parameters // null)] == [null])
-' &lt;&lt;&lt;"${detail}" &gt;/dev/null
+' <<<"${detail}" >/dev/null
 git diff --exit-code HEAD -- .github/workflows/release.yml</automated>
   </verify>
   <done>

--- a/.planning/quick/260731-sjq-review-and-address-issue-99-by-protectin/260731-sjq-PLAN.md
+++ b/.planning/quick/260731-sjq-review-and-address-issue-99-by-protectin/260731-sjq-PLAN.md
@@ -1,0 +1,172 @@
+---
+phase: quick/260731-sjq
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified: []
+autonomous: true
+requirements: [ISSUE-99]
+
+must_haves:
+  truths:
+    - "Published tags matching refs/tags/v* cannot be updated, force-pushed, or deleted."
+    - "New refs/tags/v* tags can still be created because the ruleset has no creation restriction."
+    - "Exactly one active repository ruleset named 'Protect published version tags' owns the intended v* protection, with no bypass actors."
+    - "The release workflow remains unchanged, so legitimate same-tag retries and backfills are not rejected by a sum.golang.org existence check."
+  artifacts:
+    - path: "GitHub repository ruleset: Protect published version tags"
+      provides: "Active tag protection for refs/tags/v*"
+      contains: "update, deletion, non_fast_forward"
+  key_links:
+    - from: "ruleset conditions.ref_name.include"
+      to: "refs/tags/v*"
+      via: "exact repository ruleset ref-name condition"
+      pattern: "refs/tags/v\\*"
+    - from: "ruleset rules"
+      to: "published tag immutability"
+      via: "update, deletion, and non_fast_forward rule types with no bypass actors"
+      pattern: "update|deletion|non_fast_forward"
+---
+
+<objective>
+Protect published version tags by creating one active GitHub repository ruleset for `refs/tags/v*` after a read-before-write duplicate check.
+
+Purpose: Prevent another published Go module tag from being re-pointed or deleted, which would permanently conflict with the checksum already recorded by the public module ecosystem.
+Output: One verified repository-level tag ruleset. No source or workflow changes.
+</objective>
+
+<execution_context>
+@/Users/tazarov/.codex/get-shit-done/workflows/execute-plan.md
+@/Users/tazarov/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@AGENTS.md
+@.planning/STATE.md
+@.planning/config.json
+@.github/workflows/release.yml
+
+<interfaces>
+- Use the repository REST endpoint `repos/{owner}/{repo}/rulesets` through `gh api`; placeholders must resolve from the current checkout rather than hard-coding a repository name.
+- The current GitHub REST schema accepts `target: tag`, `enforcement: active`, `conditions.ref_name`, and the `update`, `deletion`, and `non_fast_forward` rule types. The `update` rule must set `parameters.update_allows_fetch_and_merge` to `false`.
+- Creating a repository ruleset requires repository Administration write permission. The supplied live state says the current user has ADMIN permission, but execution must verify this before mutation.
+- `.github/workflows/release.yml` intentionally accepts existing tags through `workflow_dispatch` for retries and backfills. Do not add a sum.golang.org or other fail-on-existing-tag preflight: it would reject valid reruns and can race with first publication.
+</interfaces>
+</context>
+
+<source_audit>
+
+| Source | ID | Item | Task | Status |
+|--------|----|------|------|--------|
+| GOAL | QG-01 | Protect published `v*` tags from rewrites and deletions | 1 | COVERED |
+| REQ | ISSUE-99 | Add an active repository tag ruleset for `refs/tags/v*` | 1 | COVERED |
+| REQ | ISSUE-99 | Prevent updates, force pushes, and deletions without blocking new tag creation | 1 | COVERED |
+| RESEARCH | API-01 | Use the GitHub repository rulesets REST endpoint and current tag-rule schema | 1 | COVERED |
+| CONTEXT | C-01 | Read before write and avoid duplicate or conflicting rulesets | 1 | COVERED |
+| CONTEXT | C-02 | Verify the stored remote ruleset after creation | 2 | COVERED |
+| CONTEXT | C-03 | Do not add a release-workflow checksum preflight or otherwise change `release.yml` | 2 | COVERED |
+| CONTEXT | C-04 | Keep artifacts free of prohibited repository information; use squash merge if a PR is later needed | 1, 2 | COVERED |
+
+</source_audit>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Guard and create the immutable published-tag ruleset</name>
+  <files>Remote artifact: GitHub repository ruleset `Protect published version tags`</files>
+  <action>
+Run from the repository root. Confirm `gh auth status` succeeds and `gh api 'repos/{owner}/{repo}' --jq '.permissions.admin'` returns `true`; stop without mutation if not.
+
+Before any POST, list repository-owned tag rulesets with `GET repos/{owner}/{repo}/rulesets?includes_parents=false&amp;targets=tag&amp;per_page=100`, following pagination, then fetch each returned ruleset by ID so conditions, rules, enforcement, and bypass actors are available. Use the deterministic name `Protect published version tags`. Treat an existing ruleset as the desired no-op result only when it is active, targets tags, has `include: ["refs/tags/v*"]` and an empty exclude list, has no bypass actors, contains exactly the `update`, `deletion`, and `non_fast_forward` rule types, and the update rule has `update_allows_fetch_and_merge: false`.
+
+If a non-equivalent ruleset has the deterministic name or overlaps `refs/tags/v*` through that exact include, `refs/tags/*`, or `~ALL`, stop before mutation and report its ID and full configuration. Do not create a duplicate, overwrite an existing ruleset, or delete anything. If one exact desired ruleset already exists, skip creation and continue to Task 2.
+
+When no candidate exists, submit one POST to `repos/{owner}/{repo}/rulesets` with the recommended GitHub media type and API version `2026-03-10`. Send a JSON body with name `Protect published version tags`, `target: "tag"`, `enforcement: "active"`, `bypass_actors: []`, `conditions.ref_name.include: ["refs/tags/v*"]`, `conditions.ref_name.exclude: []`, and rules `{type: "update", parameters: {update_allows_fetch_and_merge: false}}`, `{type: "deletion"}`, and `{type: "non_fast_forward"}`. Do not add a `creation` rule: new release tags must remain creatable. Capture the returned ruleset ID for diagnostics.
+
+Do not edit `.github/workflows/release.yml`, query sum.golang.org, alter issue #99, or make any other repository-setting change. No PR is required for the remote ruleset; if later work introduces a PR, follow the repository's squash-merge-only rule.
+  </action>
+  <verify>
+    <automated>set -euo pipefail
+name='Protect published version tags'
+pages="$(gh api 'repos/{owner}/{repo}/rulesets?includes_parents=false&amp;targets=tag&amp;per_page=100' --paginate --slurp)"
+test "$(jq --arg name "${name}" '[.[][] | select(.name == $name)] | length' &lt;&lt;&lt;"${pages}")" -eq 1
+id="$(jq -r --arg name "${name}" '.[][] | select(.name == $name) | .id' &lt;&lt;&lt;"${pages}")"
+gh api "repos/{owner}/{repo}/rulesets/${id}" --jq '.id' | grep -Eq '^[0-9]+$'</automated>
+  </verify>
+  <done>
+The authenticated administrator either creates exactly one desired ruleset or safely reuses an exact existing one; any collision stops before write, and the resulting ruleset is addressable by a single repository ruleset ID.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Verify the stored protection and unchanged release path</name>
+  <files>.github/workflows/release.yml (read-only), remote repository ruleset (read-only)</files>
+  <action>
+Re-read the repository-owned tag rulesets from GitHub after Task 1 and resolve the single ruleset named `Protect published version tags` to its full configuration. Verify the remote stored representation, not the request or Task 1 response: name, active enforcement, tag target, exact include/exclude conditions, empty bypass list, the three exact rule types, and `update_allows_fetch_and_merge: false` must all match. Also confirm no `creation` rule is present.
+
+Verify `.github/workflows/release.yml` is byte-for-byte unchanged from `HEAD`. Record in the quick-task summary that no sum.golang.org preflight was added because same-tag release retries/backfills are intentional and an existence lookup would both reject them and race first publication. Record the ruleset ID and HTML link returned by GitHub, but do not expose credentials or unrelated repository metadata.
+
+Do not test enforcement by attempting to move or delete a live tag. Structural verification through the read API is the acceptance method because a destructive probe would put published references at risk.
+  </action>
+  <verify>
+    <automated>set -euo pipefail
+name='Protect published version tags'
+pages="$(gh api 'repos/{owner}/{repo}/rulesets?includes_parents=false&amp;targets=tag&amp;per_page=100' --paginate --slurp)"
+test "$(jq --arg name "${name}" '[.[][] | select(.name == $name)] | length' &lt;&lt;&lt;"${pages}")" -eq 1
+id="$(jq -r --arg name "${name}" '.[][] | select(.name == $name) | .id' &lt;&lt;&lt;"${pages}")"
+detail="$(gh api "repos/{owner}/{repo}/rulesets/${id}")"
+jq -e --arg name "${name}" '
+  .name == $name and
+  .target == "tag" and
+  .enforcement == "active" and
+  .conditions.ref_name.include == ["refs/tags/v*"] and
+  .conditions.ref_name.exclude == [] and
+  ((.bypass_actors // []) | length == 0) and
+  (([.rules[].type] | sort) == ["deletion", "non_fast_forward", "update"]) and
+  ([.rules[] | select(.type == "update") | .parameters.update_allows_fetch_and_merge] == [false])
+' &lt;&lt;&lt;"${detail}" &gt;/dev/null
+git diff --exit-code HEAD -- .github/workflows/release.yml</automated>
+  </verify>
+  <done>
+The read API proves one active repository ruleset exactly protects `refs/tags/v*` against updates, force pushes, and deletion without blocking creation, while the release workflow remains unchanged and supports legitimate same-tag operations.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| local authenticated `gh` client -> GitHub repository administration API | An administrator credential performs the one authorized remote settings mutation |
+| ruleset ref pattern -> Git reference namespace | The condition decides which tags are protected and which tag creations remain allowed |
+| repository ruleset -> release workflow | Tag immutability must not be confused with rejecting legitimate same-tag release reruns |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-sjq-01 | Tampering | ruleset target and conditions | mitigate | Use the exact `tag` target and `refs/tags/v*` include, then verify the stored representation through a fresh GET |
+| T-sjq-02 | Elevation of Privilege | ruleset bypass actors | mitigate | Submit and verify an empty bypass list so no actor is intentionally exempted |
+| T-sjq-03 | Denial of Service | release tag creation | mitigate | Do not add a creation rule; new `v*` tags remain creatable |
+| T-sjq-04 | Tampering | duplicate or overlapping rulesets | mitigate | Fetch full existing tag rulesets before POST, reuse only an exact match, and stop on any collision rather than overwriting or duplicating it |
+| T-sjq-05 | Denial of Service | release retry/backfill path | mitigate | Leave `release.yml` unchanged and explicitly omit the fail-on-existing sum.golang.org preflight |
+| T-sjq-SC | Tampering | package-manager installs | accept | No npm, pip, cargo, Go module, or other package installation is introduced |
+</threat_model>
+
+<verification>
+The combined verification is the Task 2 read-back predicate plus `git diff --exit-code HEAD -- .github/workflows/release.yml`. It must return one exact active ruleset and no workflow diff. Do not use a live tag move or deletion as a probe.
+</verification>
+
+<success_criteria>
+- One active repository ruleset named `Protect published version tags` targets exactly `refs/tags/v*`.
+- The ruleset blocks updates, non-fast-forward changes, and deletion, has no bypass actors, and does not block creation.
+- A rerun is idempotent: it reuses an exact ruleset and refuses to create over a conflict.
+- `.github/workflows/release.yml` has no diff and contains no new sum.golang.org preflight.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260731-sjq-review-and-address-issue-99-by-protectin/260731-sjq-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260731-sjq-review-and-address-issue-99-by-protectin/260731-sjq-SUMMARY.md
+++ b/.planning/quick/260731-sjq-review-and-address-issue-99-by-protectin/260731-sjq-SUMMARY.md
@@ -1,0 +1,160 @@
+---
+phase: quick/260731-sjq
+plan: 01
+status: complete
+subsystem: repository-security
+tags: [github, rulesets, tags, release-safety]
+
+requires: []
+provides:
+  - Active repository tag ruleset protecting refs/tags/v* from updates, non-fast-forward changes, and deletion
+affects: [release-workflow, published-version-tags]
+
+tech-stack:
+  added: []
+  patterns: [read-before-write remote administration, structural verification without destructive probes]
+
+key-files:
+  created:
+    - .planning/quick/260731-sjq-review-and-address-issue-99-by-protectin/260731-sjq-SUMMARY.md
+  modified: []
+
+key-decisions:
+  - "Created the ruleset only after authentication, administrator-permission, and duplicate/overlap guards passed."
+  - "Made no follow-up mutation when GitHub canonicalized the tag update rule parameters to null; the authorized mutation was limited to one ruleset creation."
+
+patterns-established:
+  - "Repository settings changes use a read-before-write collision check and a fresh read-back."
+  - "Published references are verified structurally; live tags are never moved or deleted as a test."
+
+requirements-completed: [ISSUE-99]
+
+duration: 7min 26s
+completed: 2026-07-31
+---
+
+# Quick Task 260731-sjq: Published Version Tag Protection Summary
+
+**One active repository tag ruleset now protects `refs/tags/v*` from updates, force pushes, and deletion while leaving new version-tag creation unrestricted.**
+
+## Performance
+
+- **Duration:** 7min 26s
+- **Started:** 2026-07-31T17:40:28Z
+- **Completed:** 2026-07-31T17:47:54Z
+- **Tasks:** 2/2 complete
+- **Files modified:** 1 summary file; no source or workflow files changed
+
+## Accomplishments
+
+- Created exactly one active repository ruleset for `refs/tags/v*` after authentication, administrator-permission, duplicate, and overlap guards passed.
+- Verified the fresh stored representation contains only `update`, `deletion`, and `non_fast_forward`, with no bypass actors or creation rule.
+- Confirmed the release workflow remains byte-for-byte identical to `HEAD` and has no `sum.golang.org` preflight.
+
+## Remote Result
+
+- **Mutation:** Created, not reused
+- **Ruleset ID:** `20138470`
+- **Ruleset link:** https://github.com/amikos-tech/chroma-go-local/rules/20138470
+- **POST count:** One
+- **Other repository-setting mutations:** None
+- **Tags or issues changed:** None
+
+The preflight found zero repository-owned tag rulesets and zero deterministic-name or overlapping candidates. GitHub authentication succeeded for `github.com`, the repository was resolved from the current worktree, and the repository permission check returned `admin_permission=true` before the POST.
+
+## Verification Evidence
+
+The revised Task 2 fresh-GET predicate passed against existing ruleset `20138470`. GitHub returned this stored shape:
+
+```json
+{
+  "name": "Protect published version tags",
+  "target": "tag",
+  "enforcement": "active",
+  "include": ["refs/tags/v*"],
+  "exclude": [],
+  "bypass_actors": [],
+  "rules": [
+    {"type": "update", "parameters": null},
+    {"type": "deletion", "parameters": null},
+    {"type": "non_fast_forward", "parameters": null}
+  ]
+}
+```
+
+| Field | Stored value | Result |
+| --- | --- | --- |
+| Name | `Protect published version tags` | PASS |
+| Target | `tag` | PASS |
+| Enforcement | `active` | PASS |
+| Include | `["refs/tags/v*"]` | PASS |
+| Exclude | `[]` | PASS |
+| Bypass actors | `[]` | PASS |
+| Rule types | `["deletion","non_fast_forward","update"]` | PASS |
+| Creation rule count | `0` | PASS |
+| Update parameters | absent/null | PASS |
+
+For a ruleset with `target: "tag"`, GitHub's canonical `update` rule has absent/null parameters. `update_allows_fetch_and_merge` is branch-only, so it is not part of the accepted stored tag-rule representation. The revised verification explicitly checks this canonical shape:
+
+```text
+task_2_predicate=PASS
+update_parameters=[null]
+creation_rule_count=0
+```
+
+## Release Workflow Evidence
+
+- `git diff --exit-code HEAD -- .github/workflows/release.yml`: PASS
+- HEAD blob: `89ccda18dd3ff036fd3dfe1d80ba7c4232f89657`
+- Worktree blob: `89ccda18dd3ff036fd3dfe1d80ba7c4232f89657`
+- `sum.golang.org` preflight: absent
+
+The release workflow remains byte-for-byte unchanged. No checksum-existence preflight was added because the workflow intentionally supports same-tag retries and backfills; such a preflight would reject those legitimate runs and could race first publication.
+
+## Task Commits
+
+None. The intended result is a remote repository setting, and the executor was explicitly instructed not to commit code or GSD artifacts. The orchestrator owns the summary artifact.
+
+## Files Created/Modified
+
+- `.planning/quick/260731-sjq-review-and-address-issue-99-by-protectin/260731-sjq-SUMMARY.md` - Records the completed remote result and exact verification evidence.
+
+`.github/workflows/release.yml` was read and verified but not modified. No source code, `STATE.md`, or `ROADMAP.md` was changed.
+
+## Decisions Made
+
+- Performed exactly one POST after all guards passed.
+- Accepted GitHub's canonical absent/null parameters for the tag update rule, as specified by the revised plan.
+- Did not test enforcement by moving or deleting a live tag.
+
+## Deviations from Plan
+
+None - the stored result matches the revised plan exactly, and no follow-up mutation was needed.
+
+## Issues Encountered
+
+None. GitHub's absent/null parameters for a tag update rule are the expected canonical representation in the revised plan.
+
+## Known Stubs
+
+None.
+
+## User Setup Required
+
+None.
+
+## Next Phase Readiness
+
+The repository now has one verified active ruleset protecting published version tags. Both tasks and requirement `ISSUE-99` are complete; no further setup or source change is required.
+
+## Self-Check: PASSED
+
+- Summary file exists.
+- Ruleset `20138470` exists under the expected deterministic name.
+- Release workflow remains unchanged.
+- No unexpected worktree changes or stub markers were found.
+- Commit existence is not applicable: this execution intentionally creates no code or GSD commit, and the orchestrator owns the summary artifact.
+
+---
+*Phase: quick/260731-sjq*
+*Completed: 2026-07-31*


### PR DESCRIPTION
## Summary

Protect published `v*` tags with an active repository ruleset so released versions cannot be updated, force-pushed, or deleted.

The repository-setting change is already applied and verified. This PR records the decision and evidence in the quick-task artifacts; the release workflow remains unchanged.

## Changes

- Added one active tag ruleset for `refs/tags/v*` with `update`, `deletion`, and `non_fast_forward` restrictions.
- Kept bypass actors empty and omitted a creation restriction so new release tags remain creatable.
- Preserved legitimate same-tag release retries and backfills by leaving the release workflow unchanged.
- Restored literal Bash and URL syntax in the quick plan so its verification blocks can be copied and executed.

## Requirements Addressed

- Closes #99.

## Verification

- [x] The repository read API returns exactly one matching active tag ruleset.
- [x] Stored conditions, rule types, bypass actors, and update parameters match the intended configuration.
- [x] Both documented verification blocks parse as Bash and pass when run against the stored ruleset.
- [x] `.github/workflows/release.yml` is unchanged from `HEAD`.
- [x] `git diff --check` passes and the current plan contains no HTML entities.

Source and workflow test suites were not rerun because this branch changes only planning documentation and a repository setting.

## Key Decisions

- Verified protection structurally through the read API instead of attempting a destructive live-tag update or deletion.
- Did not add a checksum-service preflight because same-tag release retries and backfills are intentional, while an existence check would reject them and still race first publication.
- Scoped the entity cleanup to this quick-task plan because the GSD generator is not part of this repository.
