### PR TITLE
docs(planning): add Chroma 1.5.9 migration phases

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -43,6 +43,17 @@
 - [x] **SMNT-03**: `ServerSession.pruneCollectionWAL(name, options)` and `pruneAllWAL(options)` use stop-embed-op-restart pattern
 - [x] **SMNT-04**: Integration tests verify server maintenance operations in both backends
 
+### Chroma 1.5.9 Migration
+
+- [ ] **UPG-01**: All nine direct Chroma Rust dependencies and the resolved lockfile use the Chroma 1.5.9 dependency graph
+- [ ] **UPG-02**: The shim adapts the changed `Frontend::delete` region argument with documented local-mode semantics and no behavior change through the existing FFI
+- [ ] **UPG-03**: Existing exported C symbols and public Go, JNA, and Panama APIs remain backward compatible; additive Chroma 1.5.9 APIs are explicitly included or deferred
+- [ ] **UPG-04**: Rust and protobuf toolchain guidance matches the versions actually required to build the locked Chroma 1.5.9 graph
+- [ ] **COMPAT-01**: Data created by the Chroma 1.5.5 shim can be opened, read, queried, mutated, and reopened with the Chroma 1.5.9 shim
+- [ ] **COMPAT-02**: Backup, rebuild, compaction, WAL pruning, and server stop/restart operations preserve data and availability after the upgrade
+- [ ] **COMPAT-03**: Go, Rust FFI, JNA, and Panama test suites pass against Chroma 1.5.9 on the supported CI platforms
+- [ ] **COMPAT-04**: Upgrade notes document the backup prerequisite, tested rollback boundary, toolchain changes, and intentionally deferred Chroma 1.5.9 capabilities
+
 ## v2 Requirements
 
 ### Post-Parity Improvements
@@ -91,12 +102,20 @@
 | SMNT-02 | Phase 10 | Complete |
 | SMNT-03 | Phase 10 | Complete |
 | SMNT-04 | Phase 10 | Complete |
+| UPG-01 | Phase 11 | Pending |
+| UPG-02 | Phase 11 | Pending |
+| UPG-03 | Phase 11 | Pending |
+| UPG-04 | Phase 11 | Pending |
+| COMPAT-01 | Phase 12 | Pending |
+| COMPAT-02 | Phase 12 | Pending |
+| COMPAT-03 | Phase 12 | Pending |
+| COMPAT-04 | Phase 12 | Pending |
 
 **Coverage:**
-- v1 requirements: 23 total
-- Mapped to phases: 23
+- v1 requirements: 31 total
+- Mapped to phases: 31
 - Unmapped: 0
 
 ---
 *Requirements defined: 2026-03-21*
-*Last updated: 2026-03-21 after roadmap creation*
+*Last updated: 2026-08-01 for Chroma 1.5.9 migration planning*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -129,3 +129,23 @@ Phases execute in numeric order: 6 -> 7 -> 8 -> 9 -> 10
 | 8. Embedded Maintenance | v0.5.0 | 2/2 | Complete | 2026-03-26 |
 | 9. Backup API | v0.5.0 | 2/2 | Complete   | 2026-03-27 |
 | 10. Server Maintenance | v0.5.0 | 2/2 | Complete    | 2026-03-28 |
+
+### Phase 11: Migrate Rust shim from Chroma 1.5.5 to 1.5.9
+
+**Goal:** [To be planned]
+**Requirements**: TBD
+**Depends on:** Phase 10
+**Plans:** 0 plans
+
+Plans:
+- [ ] TBD (run /gsd-plan-phase 11 to break down)
+
+### Phase 12: Validate Chroma 1.5.9 cross-version data and binding compatibility
+
+**Goal:** [To be planned]
+**Requirements**: TBD
+**Depends on:** Phase 11
+**Plans:** 0 plans
+
+Plans:
+- [ ] TBD (run /gsd-plan-phase 12 to break down)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -4,6 +4,7 @@
 
 - **v0.4.0 Go Subtree Reorganization** - Phases 1-5 (complete)
 - **v0.5.0 Java API Surface** - Phases 6-10 (in progress)
+- **Chroma 1.5.9 Upgrade** - Phases 11-12 (planned)
 
 ## Phases
 
@@ -31,6 +32,11 @@ Decimal phases appear between their surrounding integers in numeric order.
 - [ ] **Phase 8: Embedded Maintenance** - Implement rebuild, compaction, and WAL prune operations on EmbeddedSession in both backends
 - [x] **Phase 9: Backup API** - Implement backup with filesystem copy, manifest generation, and option builder for both embedded and server modes (completed 2026-03-27)
 - [x] **Phase 10: Server Maintenance** - Implement stop-embed-op-restart orchestration for all maintenance operations on ServerSession (completed 2026-03-28)
+
+### Chroma 1.5.9 Upgrade
+
+- [ ] **Phase 11: Migrate Rust shim from Chroma 1.5.5 to 1.5.9** - Upgrade the Rust dependency graph and adapt the one known shim source break while preserving public binding contracts
+- [ ] **Phase 12: Validate Chroma 1.5.9 cross-version data and binding compatibility** - Prove persisted-data compatibility, maintenance behavior, and all Go/Rust/Java binding paths before release
 
 ## Phase Details
 
@@ -111,11 +117,47 @@ Plans:
 - [x] 10-01-PLAN.md -- MaintenanceResult, MaintenanceExecutor, ServerSession expansion, JNA/Panama backend wiring
 - [x] 10-02-PLAN.md -- Data-seeded integration tests for server maintenance in both JNA and Panama backends
 
+### Phase 11: Migrate Rust shim from Chroma 1.5.5 to 1.5.9
+
+**Goal:** Upgrade the Rust shim to Chroma 1.5.9, reconcile its dependency and toolchain changes, and preserve the existing C FFI, Go, JNA, and Panama contracts
+**Depends on:** Phase 10
+**Requirements:** UPG-01, UPG-02, UPG-03, UPG-04
+**Canonical refs:**
+- `.planning/phases/11-migrate-rust-shim-from-chroma-1-5-5-to-1-5-9/11-RESEARCH.md`
+**Success Criteria** (what must be TRUE):
+  1. All nine direct Chroma git dependencies are pinned to tag 1.5.9 and the committed lockfile resolves reproducibly with `--locked`, including the known `fastrace` reconciliation
+  2. The shim compiles against the new `Frontend::delete(request, region)` signature with the locally appropriate region value documented and protected by an embedded delete regression test
+  3. The exported C symbol set and the public Go, JNA, and Panama APIs remain backward compatible; additive upstream APIs are either deliberately exposed with tests or recorded as deferred
+  4. Contributor and CI guidance states the real Rust and protobuf toolchain requirements for the locked 1.5.9 graph
+  5. Fresh-data Rust, Go, JNA, and Panama smoke and integration tests pass with the migrated shim
+**Plans:** 0 plans
+
+Plans:
+- [ ] TBD (run /gsd-plan-phase 11 to break down)
+
+### Phase 12: Validate Chroma 1.5.9 cross-version data and binding compatibility
+
+**Goal:** Prove that users can upgrade existing Chroma 1.5.5 data to the 1.5.9-backed shim without losing data, maintenance behavior, or binding compatibility, and document the tested rollback boundary
+**Depends on:** Phase 11
+**Requirements:** COMPAT-01, COMPAT-02, COMPAT-03, COMPAT-04
+**Canonical refs:**
+- `.planning/phases/12-validate-chroma-1-5-9-cross-version-data-and-binding-compati/12-RESEARCH.md`
+**Success Criteria** (what must be TRUE):
+  1. A deterministic fixture created by the 1.5.5 shim is opened by 1.5.9 with collection identity, records, documents, metadata, counts, filters, and representative query results intact
+  2. The 1.5.9 shim can mutate the upgraded fixture and reopen it after process restart without data loss or result drift
+  3. Backup/restore, rebuild, compaction, WAL pruning, and server stop/restart complete against upgraded data and leave it queryable
+  4. Go, Rust FFI, JNA, and Panama compatibility tests pass across the supported CI operating systems
+  5. Upgrade documentation states the required pre-upgrade backup, the observed 1.5.9-to-1.5.5 rollback result, toolchain changes, and intentionally deferred upstream capabilities
+**Plans:** 0 plans
+
+Plans:
+- [ ] TBD (run /gsd-plan-phase 12 to break down)
+
 ## Progress
 
 **Execution Order:**
-Phases execute in numeric order: 6 -> 7 -> 8 -> 9 -> 10
-(Phases 7 and 8 can execute in parallel after Phase 6; Phases 9 and 10 depend on both 7 and 8.)
+Phases execute in numeric order: 6 -> 7 -> 8 -> 9 -> 10 -> 11 -> 12
+(Phases 7 and 8 can execute in parallel after Phase 6; Phases 9 and 10 depend on both 7 and 8; compatibility validation follows the 1.5.9 shim migration.)
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
@@ -129,23 +171,5 @@ Phases execute in numeric order: 6 -> 7 -> 8 -> 9 -> 10
 | 8. Embedded Maintenance | v0.5.0 | 2/2 | Complete | 2026-03-26 |
 | 9. Backup API | v0.5.0 | 2/2 | Complete   | 2026-03-27 |
 | 10. Server Maintenance | v0.5.0 | 2/2 | Complete    | 2026-03-28 |
-
-### Phase 11: Migrate Rust shim from Chroma 1.5.5 to 1.5.9
-
-**Goal:** [To be planned]
-**Requirements**: TBD
-**Depends on:** Phase 10
-**Plans:** 0 plans
-
-Plans:
-- [ ] TBD (run /gsd-plan-phase 11 to break down)
-
-### Phase 12: Validate Chroma 1.5.9 cross-version data and binding compatibility
-
-**Goal:** [To be planned]
-**Requirements**: TBD
-**Depends on:** Phase 11
-**Plans:** 0 plans
-
-Plans:
-- [ ] TBD (run /gsd-plan-phase 12 to break down)
+| 11. Migrate Rust shim from Chroma 1.5.5 to 1.5.9 | Chroma 1.5.9 Upgrade | 0/TBD | Not started | - |
+| 12. Validate Chroma 1.5.9 cross-version data and binding compatibility | Chroma 1.5.9 Upgrade | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,7 +4,7 @@ milestone: v0.5.0
 milestone_name: Java API Surface
 status: "Phase 10 shipped — PR #82"
 stopped_at: Completed 10-02-PLAN.md
-last_updated: "2026-08-01T09:28:49.764Z"
+last_updated: "2026-08-01T10:29:16.199Z"
 last_activity: "2026-07-31 - Completed quick task 260731-sjq: protected published `v*` tags from updates and deletions with verified repository ruleset 20138470 (issue #99)."
 progress:
   total_phases: 7
@@ -49,6 +49,8 @@ Plan: Not started
 
 - Phase 11 added: Migrate Rust shim from Chroma 1.5.5 to 1.5.9
 - Phase 12 added: Validate Chroma 1.5.9 cross-version data and binding compatibility
+- Phase 12 edited: defined COMPAT-01 through COMPAT-04, five success criteria, and phase-local compatibility research
+- Phase 11 edited: defined UPG-01 through UPG-04, five success criteria, and phase-local upgrade research
 
 ### Decisions
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,12 +4,14 @@ milestone: v0.5.0
 milestone_name: Java API Surface
 status: "Phase 10 shipped — PR #82"
 stopped_at: Completed 10-02-PLAN.md
-last_updated: "2026-07-31T08:44:06Z"
+last_updated: "2026-08-01T09:28:49.764Z"
+last_activity: "2026-07-31 - Completed quick task 260731-sjq: protected published `v*` tags from updates and deletions with verified repository ruleset 20138470 (issue #99)."
 progress:
-  total_phases: 5
+  total_phases: 7
   completed_phases: 5
   total_plans: 11
   completed_plans: 11
+  percent: 71
 ---
 
 # Project State
@@ -42,6 +44,11 @@ Plan: Not started
 | 10 | 02 | 6min | 2 | 2 |
 
 ## Accumulated Context
+
+### Roadmap Evolution
+
+- Phase 11 added: Migrate Rust shim from Chroma 1.5.5 to 1.5.9
+- Phase 12 added: Validate Chroma 1.5.9 cross-version data and binding compatibility
 
 ### Decisions
 

--- a/.planning/phases/11-migrate-rust-shim-from-chroma-1-5-5-to-1-5-9/11-RESEARCH.md
+++ b/.planning/phases/11-migrate-rust-shim-from-chroma-1-5-5-to-1-5-9/11-RESEARCH.md
@@ -1,0 +1,208 @@
+# Phase 11: Migrate Rust shim from Chroma 1.5.5 to 1.5.9 - Research
+
+**Researched:** 2026-08-01
+**Domain:** Chroma internal Rust crates, Cargo dependency resolution, no-cgo FFI compatibility
+**Confidence:** HIGH for source and dependency changes; MEDIUM for toolchain floor until the final lockfile is produced
+
+## Summary
+
+The upgrade is feasible and should remain a narrow Rust-shim migration. A temporary copy of this repository was moved from Chroma 1.5.5 to 1.5.9, its lockfile conflict was reconciled, and the one shim source break was adapted. Rust compilation, Go tests, Rust tests, and both Java binding smoke suites then passed against fresh data.
+
+The main implementation work is small, but the upstream change surface is not: the two tags span 205 commits and 481 changed files. The phase therefore needs to preserve the evidence and explicit boundaries below rather than treating the change as nine tag substitutions.
+
+**Primary recommendation:** Upgrade the dependency graph and known delete signature in Phase 11, keep the C/Go/Java API stable, correct the documented toolchain contract, and defer persisted-data proof to Phase 12.
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research support |
+|----|-------------|------------------|
+| UPG-01 | Move all nine direct Chroma dependencies and the lockfile to 1.5.9 | The pin-only update does not resolve; `fastrace` must be reconciled with Chroma's exact version |
+| UPG-02 | Adapt the `Frontend::delete` region parameter without changing FFI behavior | This is the only direct shim compile break found by the probe |
+| UPG-03 | Preserve public binding compatibility and explicitly disposition additive upstream APIs | No exported shim signature needs to change for the migration |
+| UPG-04 | Make Rust and protobuf guidance match the resolved graph | The documented Rust 1.70+ floor is already below the current lockfile's effective floor |
+</phase_requirements>
+
+## Evidence Baseline
+
+The assessment compares the official Chroma tags directly:
+
+| Item | Chroma 1.5.5 | Chroma 1.5.9 |
+|------|--------------|--------------|
+| Tag commit | `eca66b7a58b5b2f478a5b8bae0ce7ce5f7a53f9a` | `11f3c743774db23f04a134eda1651644c25a0b35` |
+| Local pin location | `shim/Cargo.toml:19-27` | Target state for the same nine entries |
+
+Comparison links:
+
+- [Official 1.5.5 to 1.5.9 comparison](https://github.com/chroma-core/chroma/compare/1.5.5...1.5.9)
+- [Chroma 1.5.6 release](https://github.com/chroma-core/chroma/releases/tag/1.5.6)
+- [Chroma 1.5.7 release](https://github.com/chroma-core/chroma/releases/tag/1.5.7)
+- [Chroma 1.5.8 release](https://github.com/chroma-core/chroma/releases/tag/1.5.8)
+- [Chroma 1.5.9 release](https://github.com/chroma-core/chroma/releases/tag/1.5.9)
+
+### Quantified upstream change surface
+
+| Measure | Result |
+|---------|--------|
+| Commits between tags | 205 |
+| All upstream files changed | 481 |
+| All upstream line delta | +48,732 / -10,537 |
+| Files changed under the nine directly consumed crate directories | 103 |
+| Direct-crate line delta | +19,803 / -3,176 |
+| Commit subjects classified as enhancements | 104 |
+| Commit subjects classified as bug fixes | 35 |
+| Commit subjects classified as performance | 2 |
+| Commit subjects classified as maintenance | 55 |
+| Commit subjects classified as release | 9 |
+
+The subject classification is a planning aid, not an upstream semantic guarantee. The source and compile probe are the stronger evidence for local impact.
+
+## Local Dependency Surface
+
+The shim consumes these nine Chroma Rust crates directly, all pinned to the same tag:
+
+1. `chroma-frontend`
+2. `chroma-config`
+3. `chroma-system`
+4. `chroma-types`
+5. `chroma-log`
+6. `chroma-index`
+7. `chroma-segment`
+8. `chroma-sysdb`
+9. `chroma-sqlite`
+
+The resolved Chroma internal package line moves from 0.13.2 to 0.14.0. A reconciled probe lockfile changed by 222 additions and 38 removals and grew from 769 to 781 package identities. New transitive identities included `combine`, `failsafe`, `fastbloom`, `foldhash`, JNI support, `reqwest` 0.13, and platform verifier packages.
+
+### Lockfile blocker found by the probe
+
+A naive edit of the nine tags fails dependency resolution:
+
+- The current lockfile selects `fastrace` 0.7.16.
+- Chroma 1.5.9 pins `fastrace` exactly to 0.7.8.
+- Cargo must be allowed to reconcile that package while updating the Chroma git sources.
+
+This is a normal lockfile migration, but it must be an explicit plan task. A pin-only diff is not a buildable result.
+
+## Source Compatibility Findings
+
+### One direct shim compile break
+
+The local embedded delete path currently calls:
+
+```rust
+frontend.delete(request).await
+```
+
+Chroma 1.5.9 requires:
+
+```rust
+frontend.delete(request, region).await
+```
+
+The affected local call is in `run_embedded_delete_records` at `shim/src/lib.rs:2614`. Chroma's own in-process property-test helper passes an empty string, and the temporary local probe also compiled and passed with `String::new()`. The implementation plan should still record why the selected value is correct for local embedded mode and add a delete regression test; it should not smuggle in a cloud-only regional assumption.
+
+No other direct shim call-site break was found by `cargo check --all-targets` after resolving the lockfile.
+
+### Additive Chroma capabilities
+
+Chroma 1.5.9 adds capabilities that do not need to be exposed for this dependency migration:
+
+- get a collection by UUID (`getCollectionById` in client-facing APIs)
+- collection `fork_count`
+- `ReadLevel::IndexAndBoundedWal`
+- sparse-index algorithm selection with `Wand` and `MaxScore`
+- MaxScore tenant configuration
+
+Recommendation: record these as deferred unless discussion identifies an immediate user-facing requirement. Adding API surface would increase the regression area without being necessary to consume 1.5.9.
+
+### Behavioral and configuration changes to retain in test coverage
+
+- Embedding validation now rejects NaN and infinite values.
+- Configuration adds optional/defaulted region, stdout tracing, log scouting, and MaxScore tenant controls.
+- These additions appear default-compatible, but config parsing tests should cover existing Go and Java generated YAML.
+
+## Persistence Assessment
+
+Static comparison found no local SQLite migration added between 1.5.5 and 1.5.9 and no changes in the key local persistence paths examined:
+
+- Python `local_persistent_hnsw.py`
+- Rust `local_segment_manager.rs`
+- Rust `sqlite_log.rs`
+
+The HNSW git revision already resolved by this repository is also unchanged by the successful 1.5.9 probe. This lowers format-risk, but it does not prove that an existing mixed SQLite/HNSW directory survives a real upgrade. That proof belongs to Phase 12.
+
+## Toolchain Finding
+
+The repository currently documents Rust 1.70+ in `README.md`, while CI pins Rust 1.93.1. A direct build with Rust 1.85 fails because packages in the existing 1.5.5 lockfile already require Rust 1.88. This mismatch predates the Chroma 1.5.9 upgrade.
+
+Phase 11 should determine the minimum supported Rust version from the final lockfile and align contributor guidance and validation with that evidence. Do not attribute the entire floor change to Chroma 1.5.9 unless the final before/after lock analysis proves it.
+
+The README also says protobuf compiler 31.x matches Chroma 1.5.5. The phase should verify Chroma 1.5.9's protobuf requirement and update that wording even if the numeric version remains unchanged.
+
+## Completed Feasibility Probe
+
+A disposable repository copy was changed as follows:
+
+1. Pin all nine direct Chroma crates to tag 1.5.9.
+2. Reconcile the `fastrace` lockfile conflict.
+3. Pass an empty local region to the changed delete method.
+
+Results:
+
+| Check | Result |
+|-------|--------|
+| `cargo check --all-targets` | Passed |
+| `make test` | Passed against fresh data; expected skips/warnings remained |
+| `make test-rust` | Passed: 42 unit tests and 2 FFI integration tests |
+| `make test-java` | Passed for both JNA and Panama |
+
+These results prove source feasibility and fresh-database behavior on one local environment. They do not prove persisted-data upgrade, reverse rollback, or the full CI operating-system matrix.
+
+## Recommended Plan Boundaries
+
+### Task 1: Dependency and source migration
+
+- update the nine Chroma tags together
+- reconcile only the lockfile changes required by the new graph
+- adapt the delete region parameter with a focused regression test
+- run locked Cargo checks and inspect duplicate/version changes
+
+### Task 2: Compatibility and toolchain contract
+
+- compare exported symbols and public Go/JNA/Panama API surfaces before and after
+- verify existing configuration builders still parse with new defaults
+- establish and document the actual Rust and protobuf requirements
+- explicitly list additive Chroma APIs as included or deferred
+
+### Task 3: Fresh-data verification
+
+- run Rust unit/FFI, Go, JNA, and Panama tests
+- run repository lint targets
+- leave cross-version fixtures and destructive data operations to Phase 12
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Lockfile resolves but carries unintended duplicate major versions | Medium | Medium | Review `cargo tree --duplicates` and explain material additions |
+| Delete compiles with the wrong region semantics | Low | High | Follow the local-mode upstream precedent and add a real delete test |
+| Public ABI changes accidentally while adapting internals | Low | High | Diff exported symbols and run all binding smoke tests |
+| Toolchain promise remains lower than the locked graph | High | Medium | Test the claimed minimum and align README/CI guidance |
+| New upstream features expand phase scope | Medium | Medium | Default to documented deferral; require an explicit requirement to expose them |
+| Fresh-data success is mistaken for upgrade proof | High | High | Make Phase 12 a release gate and keep its fixture criteria explicit |
+
+## Questions for Discuss Phase
+
+1. Confirm that additive 1.5.9 APIs remain deferred unless there is a concrete consumer.
+2. Confirm the local empty-region behavior for embedded delete, or identify a real repository configuration source for it.
+3. Decide whether to advertise the measured minimum Rust version or simply pin the supported CI/development version.
+4. Decide whether Phase 11 must finish on every supported CI platform before Phase 12 starts, or whether Phase 12 owns the complete matrix.
+
+## Planner Checklist
+
+- [ ] Every one of UPG-01 through UPG-04 maps to at least one task and verification command.
+- [ ] The lockfile update is reviewed as a dependency migration, not accepted as generated noise.
+- [ ] The delete regression test reaches the real embedded frontend.
+- [ ] ABI/API comparison is explicit for C, Go, JNA, and Panama.
+- [ ] Fresh-data tests are not presented as cross-version persistence proof.
+- [ ] Phase 12 remains blocked on the migrated shim and owns the persisted fixture.

--- a/.planning/phases/12-validate-chroma-1-5-9-cross-version-data-and-binding-compati/12-RESEARCH.md
+++ b/.planning/phases/12-validate-chroma-1-5-9-cross-version-data-and-binding-compati/12-RESEARCH.md
@@ -1,0 +1,209 @@
+# Phase 12: Validate Chroma 1.5.9 Cross-Version Data and Binding Compatibility - Research
+
+**Researched:** 2026-08-01
+**Domain:** Persisted-data migration, backup/maintenance safety, cross-language FFI validation
+**Confidence:** HIGH for the required test shape; LOW for compatibility outcome until a real 1.5.5 fixture is exercised
+
+## Summary
+
+The Phase 11 feasibility probe proves that the 1.5.9-backed shim can compile and operate on fresh data. It does not prove the user-critical case: opening a directory created by the released 1.5.5-backed shim.
+
+Static upstream inspection suggests a low format-change risk because no local SQLite migrations or changes in the primary local persistence managers were found between the tags. That is useful evidence, not a substitute for a fixture test. SQLite metadata, HNSW files, WAL state, and maintenance operations must be exercised together.
+
+**Primary recommendation:** Make a small, deterministic 1.5.5 fixture the center of this phase. Back it up before any 1.5.9 write, validate read behavior first, then mutate/restart, run maintenance operations, and document rather than assume reverse rollback support.
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research support |
+|----|-------------|------------------|
+| COMPAT-01 | Open, read, query, mutate, and reopen 1.5.5 data with 1.5.9 | This is the main gap left by the fresh-data feasibility probe |
+| COMPAT-02 | Verify backup and maintenance behavior on upgraded data | These operations touch persisted files and stop/restart ownership boundaries |
+| COMPAT-03 | Verify all bindings on supported CI platforms | The local probe covered all bindings on one environment only |
+| COMPAT-04 | Document backup, rollback, toolchain, and deferred APIs | Reverse compatibility and operational recovery must not be implied without evidence |
+</phase_requirements>
+
+## What Is Known
+
+### Proven in the disposable 1.5.9 probe
+
+- the migrated Rust graph compiles
+- fresh embedded/server data works through the existing Go surface
+- 42 Rust unit tests and 2 Rust FFI integration tests pass
+- JNA and Panama smoke suites pass
+
+### Suggested by source inspection
+
+- no local SQLite migrations were added between Chroma 1.5.5 and 1.5.9
+- the examined local persistent HNSW, local segment manager, and SQLite log paths did not change
+- the resolved HNSW revision did not change in the probe
+
+### Not yet proven
+
+- a 1.5.5 data directory opens correctly under 1.5.9
+- data remains correct after the first 1.5.9 write and restart
+- backup/restore and maintenance work on upgraded data
+- a directory touched by 1.5.9 can be reopened by 1.5.5
+- every supported CI operating system and Java binding behaves the same
+
+## Fixture Contract
+
+The fixture should be deliberately small but cover different persisted surfaces. A useful minimum is:
+
+| Fixture element | Purpose |
+|-----------------|---------|
+| Two named collections with captured UUIDs | Verify collection identity and enumeration |
+| At least six records | Exercise more than a single HNSW node and allow filtered subsets |
+| Fixed-dimensional embeddings with known nearest neighbors | Detect query-result drift |
+| Documents including Unicode and empty-adjacent cases | Exercise document storage/encoding |
+| String, integer, float, and boolean metadata | Exercise SQLite metadata typing and filters |
+| One updated record | Carry an overwrite/update state across versions |
+| One deleted record | Carry tombstone/WAL effects across versions |
+| Non-empty WAL state where the public API permits it | Exercise prune/compaction inputs |
+
+The fixture must include a human-readable manifest containing:
+
+- exact producer revision and Chroma tag
+- creation command
+- collection IDs and expected counts
+- record IDs and expected documents/metadata
+- representative query inputs and expected ordered IDs or distance tolerances
+- checksums for persisted fixture files or archive
+
+### Fixture production options
+
+| Option | Benefit | Cost/Risk |
+|--------|---------|-----------|
+| Commit a small generated fixture plus its generator | Fast and deterministic in ordinary CI | Binary changes require provenance and checksum review |
+| Build 1.5.5 and generate on every test run | Maximum reproducibility from source | Doubles a large Rust build and depends on old graph availability |
+| Generate in a dedicated scheduled/release job | Keeps regular CI lighter | Compatibility can regress between scheduled runs |
+
+Recommendation: commit a minimal fixture and a reproducible generator, then add a separate verification that can regenerate and compare its manifest when dependency/network cost is acceptable. The discuss stage should lock this choice before planning.
+
+## Compatibility Sequence
+
+Order matters because the first 1.5.9 write may make reverse rollback impossible.
+
+```text
+1. Generate pristine data with 1.5.5
+2. Copy/backup the pristine directory
+3. Open the working copy with 1.5.9 in read paths
+4. Compare IDs, counts, metadata, filters, and queries
+5. Mutate with 1.5.9
+6. Stop and reopen with 1.5.9
+7. Run maintenance operations and recheck data
+8. Test 1.5.5 rollback separately from the untouched and touched copies
+9. Restore the pre-upgrade backup and verify recovery
+```
+
+The untouched backup is the control. Never use it as the working directory for mutation or maintenance tests.
+
+## Required Test Matrix
+
+### Version and state transitions
+
+| Producer | Consumer | State | Expected gate |
+|----------|----------|-------|---------------|
+| 1.5.5 | 1.5.9 | Pristine/read-only | Must open and match the manifest |
+| 1.5.5 | 1.5.9 | Mutate then restart | Must preserve old and new records |
+| 1.5.5 | 1.5.9 | Maintenance applied | Must remain queryable and internally consistent |
+| 1.5.5 backup | 1.5.9 | Restored copy | Must reproduce pristine expectations |
+| 1.5.9-touched | 1.5.5 | Reverse open | Observe and document; do not promise success in advance |
+
+If reverse open fails cleanly, release guidance must say rollback means restoring the pre-upgrade backup, not pointing 1.5.5 at data already modified by 1.5.9.
+
+### Data behavior assertions
+
+- collection list, name, UUID, and count
+- record get by stable IDs
+- documents and typed metadata equality
+- metadata and document filters
+- nearest-neighbor query ordering with an explicit distance tolerance
+- add, update/upsert, and delete after upgrade
+- close/reopen durability after every mutation group
+
+Avoid byte-for-byte comparison of database and HNSW files after valid operations. Logical results and integrity checks are the compatibility contract.
+
+### Maintenance and recovery assertions
+
+| Operation | Before/after assertion |
+|-----------|------------------------|
+| Backup | Destination and manifest exist; restored copy opens and matches expected data |
+| Rebuild collection | Collection remains queryable with stable logical results |
+| Compact collection/all | Counts and representative queries remain stable |
+| Prune collection/all WAL | Intended WAL reduction occurs without losing records |
+| Server maintenance | Server stops, temporary embedded operation completes, server restarts and responds |
+| Failure cleanup | Handles close once, errors remain actionable, original backup remains untouched |
+
+### Binding ownership
+
+| Surface | Minimum responsibility |
+|---------|------------------------|
+| Rust FFI tests | Direct lifecycle, error slot, and native operation coverage |
+| Go tests | Fixture read/query/mutate/reopen and public maintenance APIs |
+| Java JNA | Start/open, backup/maintenance callbacks, close and restart smoke against upgraded data |
+| Java Panama | The same lifecycle contract as JNA on Java 22+ |
+| CI OS matrix | Linux, macOS, and Windows paths used by current workflows |
+
+Java does not currently expose all embedded record CRUD operations. Do not invent a new Java CRUD API for this phase. Seed and inspect data through the existing Go/Rust paths or the server HTTP API, then use Java for the lifecycle and maintenance surfaces it already owns.
+
+## Failure Classification
+
+The tests and release notes should distinguish these outcomes:
+
+| Failure | Meaning | Release response |
+|---------|---------|------------------|
+| 1.5.9 cannot open pristine 1.5.5 data | Forward compatibility failure | Block release |
+| Open succeeds but logical results differ | Silent compatibility failure | Block release and preserve fixture |
+| First 1.5.9 mutation corrupts/reorders expected state | Write compatibility failure | Block release |
+| Maintenance breaks only upgraded data | Operational compatibility failure | Block release or explicitly remove affected operation from support |
+| 1.5.5 cannot reopen 1.5.9-touched data | Reverse rollback unsupported | Require restore-from-backup guidance; not automatically a forward-release blocker |
+| One binding or OS fails | Distribution compatibility gap | Block that artifact/platform until resolved |
+
+## Recommended Plan Boundaries
+
+### Task 1: Reproducible 1.5.5 fixture
+
+- choose and document fixture production strategy
+- create the producer and manifest/checksum path
+- assert the fixture is actually produced by the 1.5.5 dependency graph
+
+### Task 2: Forward upgrade and restart verification
+
+- validate pristine reads before any write
+- mutate through 1.5.9 and verify restart durability
+- retain the untouched control copy
+
+### Task 3: Maintenance, bindings, and rollback
+
+- run backup, rebuild, compaction, WAL pruning, and server restart cases
+- cover Rust, Go, JNA, and Panama on the CI matrix
+- test the two rollback cases and write operational guidance
+
+## Release Gate
+
+Phase 12 is complete only when:
+
+- every COMPAT requirement has an automated test or a version-controlled, reviewed manual procedure where automation is impossible
+- the pristine fixture and expected manifest are reproducible
+- forward upgrade and post-write restart pass
+- backup restore is proven
+- all supported bindings and CI platforms are green
+- release notes make no reverse-rollback claim stronger than the test evidence
+
+## Questions for Discuss Phase
+
+1. Choose committed fixture plus generator, per-run generation, or a dedicated compatibility job.
+2. Confirm whether reverse opening with 1.5.5 is informational or a hard release gate. Recommendation: informational, with backup restore as the supported rollback.
+3. Confirm the minimum representative dataset and which query/filter results must be stable.
+4. Decide whether cross-platform fixture generation is required or whether one canonical fixture can be consumed on every platform.
+
+## Planner Checklist
+
+- [ ] The plan creates data with a real 1.5.5 build, not a mocked schema.
+- [ ] Read-only checks happen before any 1.5.9 mutation.
+- [ ] The pristine copy and working copy cannot be confused.
+- [ ] Logical assertions cover SQLite metadata, vector index results, and WAL-backed mutations.
+- [ ] Maintenance operations run against upgraded data, not only a new database.
+- [ ] Java coverage uses existing APIs and does not expand public CRUD scope.
+- [ ] Rollback documentation matches the actual reverse-open and restore results.


### PR DESCRIPTION
## Summary

- define Phase 11 for the Rust dependency/source/toolchain migration and Phase 12 for persisted-data and binding compatibility
- add eight traced requirements and five concrete success criteria per phase
- seed both phases with research briefs that are canonical inputs to `gsd-discuss-phase` and automatic inputs to `gsd-plan-phase`
- update project state with the new phase count and roadmap evolution entries

## Why

The upgrade has a small direct source-compatibility change but a broader dependency and persisted-data validation surface. Splitting the work keeps the dependency/API migration separate from the evidence needed to ship it safely.

The research captures the quantified upstream diff, the `fastrace` lockfile conflict, the changed delete-region signature, additive APIs, toolchain mismatch, fresh-data probe results, persistence evidence, fixture design, maintenance matrix, and rollback boundary.

## Scope

Planning artifacts only. This PR does not change product source code or runtime behavior.

## Verification

- [x] `gsd-sdk query roadmap analyze` reports both phases as researched and preserves the Phase 11 -> Phase 12 dependency
- [x] `init.phase-op` and `init.plan-phase` resolve both research briefs
- [x] all eight new requirements are defined once and mapped to the correct phase
- [x] `git diff --check` passes
- [x] the branch diff is limited to `.planning/`

## Merge

Squash merge after required CI checks pass.
